### PR TITLE
Fixed integrated test for XRD_FitPattern's 'execute()' function

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,12 @@ on:
     branches:
       - "**" # Trigger on PRs of ANY branch
 
+concurrency:
+  # Assigns this GitHub workflow a category so that we can cancel in progress runs if
+  # a new push to the branch/pull request is made
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Build and test package
 
 on:
   push:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
       - master # Trigger on pushes to master branch
   pull_request:
     branches:
-      - "**" # Trigger on PRs to ANY branch
+      - "**" # Trigger on PRs of ANY branch
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ on:
 concurrency:
   # Assigns this GitHub workflow a category so that we can cancel in progress runs if
   # a new push to the branch/pull request is made
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,8 +12,8 @@ on:
       - "**" # Trigger on PRs of ANY branch
 
 concurrency:
-  # Assigns this GitHub workflow a category so that we can cancel in progress runs if
-  # a new push to the branch/pull request is made
+  # Assigns this GitHub workflow a name so that in-progress instances of this
+  # workflow will be cancelled if a new push is made
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ name: Build and test package
 on:
   push:
     branches:
-      - "**" # Trigger on pushes to ANY branch, including nested ones
+      - master # Trigger on pushes to master branch
   pull_request:
     branches:
       - "**" # Trigger on PRs to ANY branch

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,11 +6,10 @@ name: Build and test package
 on:
   push:
     branches:
-      - master # Should run whenever a PR is merged to 'master' branch
+      - "**" # Trigger on pushes to ANY branch, including nested ones
   pull_request:
     branches:
-      - master
-      - "**" # Should run whenever we push to a PR, regardless of which branch it targets
+      - "**" # Trigger on PRs to ANY branch
 
 jobs:
   build:

--- a/tests/test_XRD_FitPattern.py
+++ b/tests/test_XRD_FitPattern.py
@@ -31,6 +31,10 @@ execute_test_matrix = (
     ("Example1-Fe", "BCC1_Dioptas_MultiPeak_input.py"),
     ("Example1-Fe", "BCC1_Dioptas_SeriesFunctions_input.py"),
     ("Example1-Fe", "BCC1_Dioptas_SymmFixed_input.py"),
+    ("Example2-MgO", "CoSi22_MgO_DetectorPosition_input.py"),
+    ("Example2-MgO", "CoSi22_MgO_input.py"),
+    ("Example2-MgO", "CoSi22_MgO_Reverse_input.py"),
+    ("Example2-MgO", "CoSi22_MgO_Track_input.py"),
 )
 
 

--- a/tests/test_XRD_FitPattern.py
+++ b/tests/test_XRD_FitPattern.py
@@ -16,12 +16,10 @@ def reset_working_directory():
     get reset when running iterated tests, so this fixture funciton ensures that the
     working directory is reset to its initial state at the start of every test run.
     """
-    # Save the current working directory
-    cwd = Path().cwd().absolute()
-    yield  # Test runs here
 
-    # After the test, reset the working directory
-    os.chdir(cwd)
+    cwd = Path().cwd().absolute()  # Save current working directory
+    yield  # Test runs here
+    os.chdir(cwd)  # Reset working directory
 
 
 # Run the same test on different datasets and input files


### PR DESCRIPTION
Fixes an issue causing the iterated integrated tests to fail. Resets the working directory to pytest's default one after the end of every iteration, and adds a check to skip making the 'results' directory if it already exists.

Renames the package testing workflow so that the name of the workflow and the workflow file are more self-explanatory. New pushes to a Pull Request or to the 'master' branch will also cancel running instances of the package testing workflow for that branch, in order to help reduce unnecessary compute.