### PR TITLE
Fixed crystallographic operations and added unit tests

### DIFF
--- a/src/cpf/IO_functions.py
+++ b/src/cpf/IO_functions.py
@@ -20,7 +20,6 @@ from cpf.util.logging import get_logger
 logger = get_logger("cpf.IO_functions")
 
 
-
 # Needed for JSON to save fitted parameters.
 # Copied from https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array#24375113
 # on 13th November 2018
@@ -379,11 +378,11 @@ def StartStopFilesToList(
     EndNum : float, optional
         End value for the file index/number. The default is None.
     Step : int, optional
-        Step value for the indicies. The default is 1.
+        Step value for the indices. The default is 1.
     Files : list, optional
-        List of file indicies. The default is None.
+        List of file indices. The default is None.
     Keys : list, optional
-        List of key indicies for hdf5 file. The default is None.
+        List of key indices for hdf5 file. The default is None.
 
     Returns
     -------
@@ -619,7 +618,7 @@ def any_errors_huge(obj_to_inspect, large_errors=3, clean=None):
                 # - there is a value and an error
                 # - the error is less than "large_errors" * error
                 # - the value is not within error of 0
-                #       [this is a sanity check to the preceeding check -- the ratio of error/value tends to inifinty as the 
+                #       [this is a sanity check to the preceeding check -- the ratio of error/value tends to inifinty as the
                 #         value becomes very small.]
                 #       [without this there is lots of discarding the previous fit when the profile values are close to 0]
                 if (
@@ -630,7 +629,7 @@ def any_errors_huge(obj_to_inspect, large_errors=3, clean=None):
                     and obj_to_inspect["peak"][k][comp + "_err"][j]
                     / obj_to_inspect["peak"][k][comp][j]
                     >= large_errors
-                    and np.abs(obj_to_inspect["peak"][k][comp][j]) 
+                    and np.abs(obj_to_inspect["peak"][k][comp][j])
                     - obj_to_inspect["peak"][k][comp + "_err"][j]
                     >= 0
                 ):

--- a/src/cpf/h5_functions.py
+++ b/src/cpf/h5_functions.py
@@ -95,21 +95,21 @@ def image_key_validate(h5key_list, key_start, key_end, key_step):
 
     fail = 0
 
-    number_indicies = len(h5key_list)
+    number_indices = len(h5key_list)
 
-    if len(key_start) != (1 | number_indicies):
+    if len(key_start) != (1 | number_indices):
         logger.error(
             " ".join(map(str, [("There are the wrong number of start positions")]))
         )
         fail = +1
 
-    if len(key_end) != (1 | number_indicies):
+    if len(key_end) != (1 | number_indices):
         logger.error(
             " ".join(map(str, [("There are the wrong number of end positions")]))
         )
         fail = +1
 
-    if len(key_step) != (1 | number_indicies):
+    if len(key_step) != (1 | number_indices):
         logger.error(
             " ".join(map(str, [("There are the wrong number of step lengths")]))
         )
@@ -436,7 +436,7 @@ def get_image_key_strings(
             # if empty then list numbers.
             labels_temp = np.array(range(number_data))
             # FIXME: We are zero counting the images and the indecies. It might be better to 1 count them.
-            # if so to 1 count the indicies we add 1 to the prewvious line.
+            # if so to 1 count the indices we add 1 to the prewvious line.
             # the counting over the arrays needs to be done in get_image_keys
             labels_temp = unique_labels(labels_temp, number_data=number_data)
         elif key_names[i] == "/":
@@ -708,12 +708,12 @@ def image_key_validate_new(
     if "h5_iterate" != None:
         num_iter = len(h5_iterate)
         if fit_settings:
-            number_indicies = len(
+            number_indices = len(
                 [a.start() for a in list(re.finditer("\*", fit_settings.h5_datakey))]
             )
-            if not (num_iter == number_indicies or num_iter == number_indicies - 1):
+            if not (num_iter == number_indices or num_iter == number_indices - 1):
                 errors.append(
-                    "The number of iterations is not the same as, or 1 less than, the number of indicies in the data"
+                    "The number of iterations is not the same as, or 1 less than, the number of indices in the data"
                 )
         for i in range(num_iter):
             dict_keys = list(h5_iterate[i].keys())
@@ -1005,7 +1005,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
 
     if len(keylist) == 0:
         raise ValueError(
-            "No keys have been found. Check that the indicies iterating over are in the hdf5 file."
+            "No keys have been found. Check that the indices iterating over are in the hdf5 file."
         )
 
     # iterate over the keylist and expand with labels.

--- a/src/cpf/output_formatters/WritePolydefix.py
+++ b/src/cpf/output_formatters/WritePolydefix.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import cpf.output_formatters.WriteMultiFit as WriteMultiFit
 from cpf.IO_functions import make_outfile_name
-from cpf.output_formatters.crystallographic_operations import indices4to3
+from cpf.output_formatters.crystallographic_operations import plane_indices_4_to_3
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WritePolydefix")
@@ -350,7 +350,7 @@ def WriteOutput(
                     else:
                         m = hkl[pos : pos + 1]
                         pos = pos + 1
-                    HKL = indices4to3(np.array([h, k, l, m], dtype=int))
+                    HKL = plane_indices_4_to_3(np.array([h, k, l, m], dtype=int))
                     h, k, l = HKL
                 text_file.write(" %5i    %s    %s    %s\n" % (use, h, k, l))
 

--- a/src/cpf/output_formatters/WritePolydefix.py
+++ b/src/cpf/output_formatters/WritePolydefix.py
@@ -7,12 +7,11 @@ from pathlib import Path
 import numpy as np
 
 import cpf.output_formatters.WriteMultiFit as WriteMultiFit
-from cpf.output_formatters.crystallographic_operations import indicies4to3
 from cpf.IO_functions import make_outfile_name
+from cpf.output_formatters.crystallographic_operations import indices4to3
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WritePolydefix")
-
 
 
 def Requirements():
@@ -325,7 +324,7 @@ def WriteOutput(
                     hkl = "000"
                     use = 0
                 pos = 0
-                
+
                 if hkl[0] == "-":
                     h = hkl[pos : pos + 2]
                     pos = pos + 2
@@ -351,7 +350,7 @@ def WriteOutput(
                     else:
                         m = hkl[pos : pos + 1]
                         pos = pos + 1
-                    HKL = indicies4to3(np.array([h,k,l,m], dtype=int))
+                    HKL = indices4to3(np.array([h, k, l, m], dtype=int))
                     h, k, l = HKL
                 text_file.write(" %5i    %s    %s    %s\n" % (use, h, k, l))
 

--- a/src/cpf/output_formatters/crystallographic_operations.py
+++ b/src/cpf/output_formatters/crystallographic_operations.py
@@ -2,90 +2,83 @@
 # -*- coding: utf-8 -*-
 
 
-
-__all__ = ["indicies4to3", "indicies3to4"]
+__all__ = ["indices4to3", "indices3to4"]
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 
-
-def indicies4to3(MBindicies: np.typing.ArrayLike) -> np.ndarray:
+def indices4to3(mb_indices: ArrayLike) -> np.ndarray:
     """
-    Cnoverts set of Miller-Bravais (hkil) indicies into Miller (hkl) indicies
+    Converts set of Miller-Bravais (hkil) indices into Miller (hkl) indices
 
     Parameters
     ----------
-    Mindicies : np.typing.ArrayLike
-        (...,4) array of Miller indicies.
+    mb_indices : ArrayLike
+        (...,4) array of Miller-Bravais indices.
 
     Raises
     ------
     ValueError
-        If there are not 4 indicies.
-        If the sum of the first three indicies is not 0.
+        If there are not 4 indices.
+        If the sum of the first three indices is not 0.
 
     Returns
     -------
-    MBindicies : np.array
-        (...,3) array of Miller-Bravais indicies.
-
-    """
-    """
-    
-    Returns
-    -------
-    None.
+    m_indices : np.array
+        (...,3) array of Miller indices.
 
     """
 
-    #check inputs are the right size
-    MBindicies = np.atleast_1d(MBindicies)
-    if MBindicies.shape[-1] != 4:
-        raise ValueError("This function takes 4 value Miller-Bravais indicies as inputs.")
-    if not np.allclose(MBindicies[...,:3].sum(axis=-1), 0.0):
-        raise ValueError('Invalid inputs: the first three values must sum to zero')
+    # check inputs are the right size
+    mb_indices = np.atleast_1d(mb_indices)
+    if mb_indices.shape[-1] != 4:
+        raise ValueError(
+            "This function takes 4 value Miller-Bravais indices as inputs."
+        )
+    if not np.allclose(mb_indices[..., :3].sum(axis=-1), 0.0):
+        raise ValueError("Invalid inputs: the first three values must sum to zero")
 
-    #do conversion
-    Mindicies = np.zeros(MBindicies.shape[:-1]+ (3,), dtype=int)
-    Mindicies[..., 0] = int(MBindicies[..., 0] - MBindicies[..., 2])
-    Mindicies[..., 1] = int(MBindicies[..., 1] - MBindicies[..., 2])
-    Mindicies[..., 2] = int(MBindicies[..., 3])
-    
-    return Mindicies.squeeze()
+    # do conversion
+    m_indices = np.zeros(mb_indices.shape[:-1] + (3,), dtype=int)
+    m_indices[..., 0] = int(mb_indices[..., 0] - mb_indices[..., 2])
+    m_indices[..., 1] = int(mb_indices[..., 1] - mb_indices[..., 2])
+    m_indices[..., 2] = int(mb_indices[..., 3])
 
-    
-    
-def indicies3to4(Mindicies: np.typing.ArrayLike) -> np.ndarray:
+    return m_indices.squeeze()
+
+
+def indices3to4(m_indices: ArrayLike) -> np.ndarray:
     """
-    Cnoverts Miller (hkl) indicies into Miller-Bravais (hkil) indicies 
+    Cnoverts Miller (hkl) indices into Miller-Bravais (hkil) indices
 
     Parameters
     ----------
-    Mindicies : np.typing.ArrayLike
-        (...,3) array of Miller indicies.
+    m_indices : ArrayLike
+        (...,3) array of Miller indices.
 
     Raises
     ------
     ValueError
-        If there are not 4 indicies.
-        If the sum of the first three indicies is not 0.
+        If there are not 4 indices.
+        If the sum of the first three indices is not 0.
 
     Returns
     -------
-    MBindicies : np.array
-        (...,4) array of Miller-Bravais indicies.
+    mb_indices : np.array
+        (...,4) array of Miller-Bravais indices.
 
     """
-    #check inputs are the right size
-    Mindicies = np.atleast_1d(Mindicies)
-    if Mindicies.shape[-1] != 3:
-        raise ValueError("This function takes 3 value Miller indicies as inputs.")
+    # check inputs are the right size
+    m_indices = np.atleast_1d(m_indices)
+    if m_indices.shape[-1] != 3:
+        raise ValueError("This function takes 3 value Miller indices as inputs.")
 
-    #do conversion
-    MBindicies = np.zeros(Mindicies.shape[:-1]+ (4,), dtype=int)
-    MBindicies[..., 0] = 1/3 * (2* Mindicies[..., 0] - Mindicies[..., 1])
-    MBindicies[..., 1] = 1/3 * (2* Mindicies[..., 1] - Mindicies[..., 0])
-    MBindicies[..., 2] = - (MBindicies[..., 0] + MBindicies[..., 1])
-    MBindicies[..., 3] = Mindicies[..., 2]
-    
-    return MBindicies.squeeze()
+    # do conversion
+    mb_indices = np.zeros(m_indices.shape[:-1] + (4,), dtype=int)
+    mb_indices[..., 0] = 1 / 3 * (2 * m_indices[..., 0] - m_indices[..., 1])
+    mb_indices[..., 1] = 1 / 3 * (2 * m_indices[..., 1] - m_indices[..., 0])
+    mb_indices[..., 2] = -(mb_indices[..., 0] + mb_indices[..., 1])
+    mb_indices[..., 3] = m_indices[..., 2]
+
+    return mb_indices.squeeze()

--- a/src/cpf/output_formatters/crystallographic_operations.py
+++ b/src/cpf/output_formatters/crystallographic_operations.py
@@ -2,15 +2,51 @@
 # -*- coding: utf-8 -*-
 
 
-__all__ = ["indices4to3", "indices3to4"]
+__all__ = ["plane_indices_4_to_3", "vector_indices_3_to_4"]
 
 import numpy as np
 from numpy.typing import ArrayLike
 
 
-def indices4to3(mb_indices: ArrayLike) -> np.ndarray:
+def plane_indices_3_to_4(m_indices: ArrayLike) -> np.ndarray:
     """
-    Converts set of Miller-Bravais (hkil) indices into Miller (hkl) indices
+    Converts set of Miller plane indices (hkl) into Miller-Bravais indices (hkil).
+
+    Parameters
+    ----------
+    m_indices : ArrayLike
+        (...,3) array of Miller indices.
+
+    Raises
+    ------
+    ValueError
+        If there are not 3 indices.
+
+    Returns
+    -------
+    m_indices : np.array
+        (...,4) array of Miller-Bravais indices.
+
+    """
+
+    # check inputs are the right size
+    m_indices = np.atleast_1d(m_indices)
+    if m_indices.shape[-1] != 3:
+        raise ValueError("This function takes 3 value Miller indices as inputs.")
+
+    # do conversion
+    mb_indices = np.zeros(m_indices.shape[:-1] + (4,), dtype=int)
+    mb_indices[..., 0] = m_indices[..., 0]
+    mb_indices[..., 1] = m_indices[..., 1]
+    mb_indices[..., 2] = -(m_indices[..., 0] + m_indices[..., 1])
+    mb_indices[..., 3] = m_indices[..., 2]
+
+    return mb_indices.squeeze()
+
+
+def plane_indices_4_to_3(mb_indices: ArrayLike) -> np.ndarray:
+    """
+    Converts set of Miller-Bravais plane indices (hkil) into Miller (hkl) indices
 
     Parameters
     ----------
@@ -41,21 +77,58 @@ def indices4to3(mb_indices: ArrayLike) -> np.ndarray:
 
     # do conversion
     m_indices = np.zeros(mb_indices.shape[:-1] + (3,), dtype=int)
-    m_indices[..., 0] = int(mb_indices[..., 0] - mb_indices[..., 2])
-    m_indices[..., 1] = int(mb_indices[..., 1] - mb_indices[..., 2])
-    m_indices[..., 2] = int(mb_indices[..., 3])
+    m_indices[..., 0] = mb_indices[..., 0]
+    m_indices[..., 1] = mb_indices[..., 1]
+    m_indices[..., 2] = mb_indices[..., 3]
 
     return m_indices.squeeze()
 
 
-def indices3to4(m_indices: ArrayLike) -> np.ndarray:
+def vector_indices_3_to_4(m_indices: ArrayLike) -> np.ndarray:
     """
-    Cnoverts Miller (hkl) indices into Miller-Bravais (hkil) indices
+    Converts Miller vector indices (uvw) into Miller-Bravais indices (UVTW)
 
     Parameters
     ----------
     m_indices : ArrayLike
-        (...,3) array of Miller indices.
+        (...,3) array of Miller vector indices.
+
+    Raises
+    ------
+    ValueError
+        If there are not 3 indices.
+
+    Returns
+    -------
+    mb_indices : np.array
+        (...,4) array of Miller-Bravais indices.
+    """
+    # check inputs are the right size
+    m_indices = np.atleast_1d(m_indices)
+    if m_indices.shape[-1] != 3:
+        raise ValueError("This function takes 3 value Miller indices as inputs.")
+
+    # Convert from uvw to UVTW
+    mb_indices = np.zeros(m_indices.shape[:-1] + (4,), dtype=int)
+    mb_indices[..., 0] = 2 * m_indices[..., 0] - m_indices[..., 1]
+    mb_indices[..., 1] = 2 * m_indices[..., 1] - m_indices[..., 0]
+    mb_indices[..., 2] = -(mb_indices[..., 0] + mb_indices[..., 1])
+    mb_indices[..., 3] = m_indices[..., 2] * 3
+
+    # Divide by highest common factor
+    mb_indices = mb_indices / np.gcd.reduce(mb_indices)
+
+    return mb_indices.squeeze()
+
+
+def vector_indices_4_to_3(mb_indices: ArrayLike):
+    """
+    Converts Miller-Bravais vector indices (UVTW) into Miller indices (uvw)
+
+    Parameters
+    ----------
+    mb_indices : ArrayLike
+        (...,4) array of Miller-Bravais indices.
 
     Raises
     ------
@@ -65,20 +138,27 @@ def indices3to4(m_indices: ArrayLike) -> np.ndarray:
 
     Returns
     -------
-    mb_indices : np.array
-        (...,4) array of Miller-Bravais indices.
-
+    m_indices : np.array
+        (...,3) array of Miller indices.
     """
-    # check inputs are the right size
-    m_indices = np.atleast_1d(m_indices)
-    if m_indices.shape[-1] != 3:
-        raise ValueError("This function takes 3 value Miller indices as inputs.")
 
-    # do conversion
-    mb_indices = np.zeros(m_indices.shape[:-1] + (4,), dtype=int)
-    mb_indices[..., 0] = 1 / 3 * (2 * m_indices[..., 0] - m_indices[..., 1])
-    mb_indices[..., 1] = 1 / 3 * (2 * m_indices[..., 1] - m_indices[..., 0])
-    mb_indices[..., 2] = -(mb_indices[..., 0] + mb_indices[..., 1])
-    mb_indices[..., 3] = m_indices[..., 2]
+    # Check inputs are the right size and are valid Miller-Bravais indices
+    mb_indices = np.atleast_1d(mb_indices)
+    if mb_indices.shape[-1] != 4:
+        raise ValueError(
+            "This function takes 4 value Miller-Bravais indices as inputs."
+        )
+    if not np.allclose(mb_indices[..., :3].sum(axis=-1), 0.0):
+        raise ValueError(
+            "This is not a valid Miller-Bravais index. "
+            "The sum of the first three indices must be equal to 0"
+        )
 
-    return mb_indices.squeeze()
+    # Convert from UVTW to uvw
+    m_indices = np.zeros(mb_indices.shape[:-1] + (3,), dtype=int)
+    m_indices[0] = 2 * mb_indices[..., 0] + mb_indices[..., 1]
+    m_indices[1] = 2 * mb_indices[..., 1] + mb_indices[..., 0]
+    m_indices[2] = mb_indices[..., 3]
+    m_indices = m_indices / np.gcd.reduce(m_indices)
+
+    return m_indices.squeeze()

--- a/tests/output_formatters/test_crystallographic_operations.py
+++ b/tests/output_formatters/test_crystallographic_operations.py
@@ -1,0 +1,270 @@
+from typing import Callable
+
+import numpy as np
+import pytest
+from cpf.output_formatters.crystallographic_operations import (
+    plane_indices_3_to_4,
+    plane_indices_4_to_3,
+    vector_indices_3_to_4,
+    vector_indices_4_to_3,
+)
+from numpy.testing import assert_equal
+
+plane_indices_test_matrix = (
+    # Miller indices | Miller-Bravais indices | Input Type
+    ((0, 0, 1), (0, 0, 0, 1), tuple),
+    ((0, 1, 0), (0, 1, -1, 0), np.ndarray),
+    ((0, 1, 1), (0, 1, -1, 1), list),
+    ((1, 0, 0), (1, 0, -1, 0), tuple),
+    ((1, 0, 1), (1, 0, -1, 1), np.ndarray),
+    ((1, 1, 0), (1, 1, -2, 0), list),
+    ((1, 1, 1), (1, 1, -2, 1), tuple),
+    ((0, 0, 2), (0, 0, 0, 2), np.ndarray),
+    ((0, 1, 2), (0, 1, -1, 2), list),
+    ((0, 2, 0), (0, 2, -2, 0), tuple),
+    ((0, 2, 1), (0, 2, -2, 1), np.ndarray),
+    ((0, 2, 2), (0, 2, -2, 2), list),
+    ((1, 0, 2), (1, 0, -1, 2), tuple),
+    ((1, 1, 2), (1, 1, -2, 2), np.ndarray),
+    ((1, 2, 0), (1, 2, -3, 0), list),
+    ((1, 2, 1), (1, 2, -3, 1), tuple),
+    ((1, 2, 2), (1, 2, -3, 2), np.ndarray),
+    ((2, 0, 0), (2, 0, -2, 0), list),
+    ((2, 0, 1), (2, 0, -2, 1), tuple),
+    ((2, 0, 2), (2, 0, -2, 2), np.ndarray),
+    ((2, 1, 0), (2, 1, -3, 0), list),
+    ((2, 1, 1), (2, 1, -3, 1), tuple),
+    ((2, 1, 2), (2, 1, -3, 2), np.ndarray),
+    ((2, 2, 0), (2, 2, -4, 0), list),
+    ((2, 2, 1), (2, 2, -4, 1), tuple),
+    ((2, 2, 2), (2, 2, -4, 2), np.ndarray),
+    # Placeholder for copying for if we want to add more
+    # ((), (), list),
+    # ((), (), tuple),
+    # ((), (), np.ndarray),
+)
+
+
+@pytest.mark.parametrize("test_params", plane_indices_test_matrix)
+def test_plane_indices_3_to_4(
+    test_params: tuple[tuple[int, ...], tuple[int, ...], type],
+):
+    # Unpack test parameters
+    m_indices, mb_indices, input_type = test_params
+
+    # Convert input indices (M indices) to correct type
+    if input_type == np.ndarray:
+        input_value = np.array(m_indices)
+    else:
+        input_value = input_type(m_indices)
+
+    # Check that object conversion has worked
+    assert isinstance(input_value, input_type)
+
+    # Run the function
+    assert_equal(
+        plane_indices_3_to_4(input_value),
+        np.array(mb_indices),
+    )
+
+
+@pytest.mark.parametrize("test_params", plane_indices_test_matrix)
+def test_plane_indices_4_to_3(
+    test_params: tuple[tuple[int, ...], tuple[int, ...], type],
+):
+    # Unpack test parameters
+    m_indices, mb_indices, input_type = test_params
+
+    # Convert input indices (M indices) to correct type
+    if input_type == np.ndarray:
+        input_value = np.array(mb_indices)
+    else:
+        input_value = input_type(mb_indices)
+
+    # Check that object conversion has worked
+    assert isinstance(input_value, input_type)
+
+    # Run the function
+    assert_equal(
+        plane_indices_4_to_3(input_value),
+        np.array(m_indices),
+    )
+
+
+vector_indices_test_matrix = (
+    # Miller indices | Miller-Bravais indices | Input Type
+    ((0, 0, 1), (0, 0, 0, 1), list),
+    ((0, 0, 2), (0, 0, 0, 1), tuple),
+    ((0, 0, 3), (0, 0, 0, 1), np.ndarray),
+    ((0, 0, 4), (0, 0, 0, 1), list),
+    ((0, 1, 0), (-1, 2, -1, 0), tuple),
+    ((0, 1, 1), (-1, 2, -1, 3), np.ndarray),
+    ((0, 1, 2), (-1, 2, -1, 6), list),
+    ((0, 1, 3), (-1, 2, -1, 9), tuple),
+    ((0, 1, 4), (-1, 2, -1, 12), np.ndarray),
+    ((0, 2, 0), (-1, 2, -1, 0), list),
+    ((0, 2, 1), (-2, 4, -2, 3), tuple),
+    ((0, 2, 2), (-1, 2, -1, 3), np.ndarray),
+    ((0, 2, 3), (-2, 4, -2, 9), list),
+    ((0, 2, 4), (-1, 2, -1, 6), tuple),
+    ((0, 3, 0), (-1, 2, -1, 0), np.ndarray),
+    ((0, 3, 1), (-1, 2, -1, 1), list),
+    ((0, 3, 2), (-1, 2, -1, 2), tuple),
+    ((0, 3, 3), (-1, 2, -1, 3), np.ndarray),
+    ((0, 3, 4), (-1, 2, -1, 4), list),
+    ((0, 4, 0), (-1, 2, -1, 0), tuple),
+    ((0, 4, 1), (-4, 8, -4, 3), np.ndarray),
+    ((0, 4, 2), (-2, 4, -2, 3), list),
+    ((0, 4, 3), (-4, 8, -4, 9), tuple),
+    ((0, 4, 4), (-1, 2, -1, 3), np.ndarray),
+    ((1, 0, 0), (2, -1, -1, 0), list),
+    ((1, 0, 1), (2, -1, -1, 3), tuple),
+    ((1, 0, 2), (2, -1, -1, 6), np.ndarray),
+    ((1, 0, 3), (2, -1, -1, 9), list),
+    ((1, 0, 4), (2, -1, -1, 12), tuple),
+    ((1, 1, 0), (1, 1, -2, 0), np.ndarray),
+    ((1, 1, 1), (1, 1, -2, 3), list),
+    ((1, 1, 2), (1, 1, -2, 6), tuple),
+    ((1, 1, 3), (1, 1, -2, 9), np.ndarray),
+    ((1, 1, 4), (1, 1, -2, 12), list),
+    ((1, 2, 0), (0, 1, -1, 0), tuple),
+    ((1, 2, 1), (0, 1, -1, 1), np.ndarray),
+    ((1, 2, 2), (0, 1, -1, 2), list),
+    ((1, 2, 3), (0, 1, -1, 3), tuple),
+    ((1, 2, 4), (0, 1, -1, 4), np.ndarray),
+    ((1, 3, 0), (-1, 5, -4, 0), list),
+    ((1, 3, 1), (-1, 5, -4, 3), tuple),
+    ((1, 3, 2), (-1, 5, -4, 6), np.ndarray),
+    ((1, 3, 3), (-1, 5, -4, 9), list),
+    ((1, 3, 4), (-1, 5, -4, 12), tuple),
+    ((1, 4, 0), (-2, 7, -5, 0), np.ndarray),
+    ((1, 4, 1), (-2, 7, -5, 3), list),
+    ((1, 4, 2), (-2, 7, -5, 6), tuple),
+    ((1, 4, 3), (-2, 7, -5, 9), np.ndarray),
+    ((1, 4, 4), (-2, 7, -5, 12), list),
+    ((2, 0, 0), (2, -1, -1, 0), tuple),
+    ((2, 0, 1), (4, -2, -2, 3), np.ndarray),
+    ((2, 0, 2), (2, -1, -1, 3), list),
+    ((2, 0, 3), (4, -2, -2, 9), tuple),
+    ((2, 0, 4), (2, -1, -1, 6), np.ndarray),
+    ((2, 1, 0), (1, 0, -1, 0), list),
+    ((2, 1, 1), (1, 0, -1, 1), tuple),
+    ((2, 1, 2), (1, 0, -1, 2), np.ndarray),
+    ((2, 1, 3), (1, 0, -1, 3), list),
+    ((2, 1, 4), (1, 0, -1, 4), tuple),
+    ((2, 2, 0), (1, 1, -2, 0), np.ndarray),
+    ((2, 2, 1), (2, 2, -4, 3), list),
+    ((2, 2, 2), (1, 1, -2, 3), tuple),
+    ((2, 2, 3), (2, 2, -4, 9), np.ndarray),
+    ((2, 2, 4), (1, 1, -2, 6), list),
+    ((2, 3, 0), (1, 4, -5, 0), tuple),
+    ((2, 3, 1), (1, 4, -5, 3), np.ndarray),
+    ((2, 3, 2), (1, 4, -5, 6), list),
+    ((2, 3, 3), (1, 4, -5, 9), tuple),
+    ((2, 3, 4), (1, 4, -5, 12), np.ndarray),
+    ((2, 4, 0), (0, 1, -1, 0), list),
+    ((2, 4, 1), (0, 2, -2, 1), tuple),
+    ((2, 4, 2), (0, 1, -1, 1), np.ndarray),
+    ((2, 4, 3), (0, 2, -2, 3), list),
+    ((2, 4, 4), (0, 1, -1, 2), tuple),
+    ((3, 0, 0), (2, -1, -1, 0), np.ndarray),
+    ((3, 0, 1), (2, -1, -1, 1), list),
+    ((3, 0, 2), (2, -1, -1, 2), tuple),
+    ((3, 0, 3), (2, -1, -1, 3), np.ndarray),
+    ((3, 0, 4), (2, -1, -1, 4), list),
+    ((3, 1, 0), (5, -1, -4, 0), tuple),
+    ((3, 1, 1), (5, -1, -4, 3), np.ndarray),
+    ((3, 1, 2), (5, -1, -4, 6), list),
+    ((3, 1, 3), (5, -1, -4, 9), tuple),
+    ((3, 1, 4), (5, -1, -4, 12), np.ndarray),
+    ((3, 2, 0), (4, 1, -5, 0), list),
+    ((3, 2, 1), (4, 1, -5, 3), tuple),
+    ((3, 2, 2), (4, 1, -5, 6), np.ndarray),
+    ((3, 2, 3), (4, 1, -5, 9), list),
+    ((3, 2, 4), (4, 1, -5, 12), tuple),
+    ((3, 3, 0), (1, 1, -2, 0), np.ndarray),
+    ((3, 3, 1), (1, 1, -2, 1), list),
+    ((3, 3, 2), (1, 1, -2, 2), tuple),
+    ((3, 3, 3), (1, 1, -2, 3), np.ndarray),
+    ((3, 3, 4), (1, 1, -2, 4), list),
+    ((3, 4, 0), (2, 5, -7, 0), tuple),
+    ((3, 4, 1), (2, 5, -7, 3), np.ndarray),
+    ((3, 4, 2), (2, 5, -7, 6), list),
+    ((3, 4, 3), (2, 5, -7, 9), tuple),
+    ((3, 4, 4), (2, 5, -7, 12), np.ndarray),
+    ((4, 0, 0), (2, -1, -1, 0), list),
+    ((4, 0, 1), (8, -4, -4, 3), tuple),
+    ((4, 0, 2), (4, -2, -2, 3), np.ndarray),
+    ((4, 0, 3), (8, -4, -4, 9), list),
+    ((4, 0, 4), (2, -1, -1, 3), tuple),
+    ((4, 1, 0), (7, -2, -5, 0), np.ndarray),
+    ((4, 1, 1), (7, -2, -5, 3), list),
+    ((4, 1, 2), (7, -2, -5, 6), tuple),
+    ((4, 1, 3), (7, -2, -5, 9), np.ndarray),
+    ((4, 1, 4), (7, -2, -5, 12), list),
+    ((4, 2, 0), (1, 0, -1, 0), tuple),
+    ((4, 2, 1), (2, 0, -2, 1), np.ndarray),
+    ((4, 2, 2), (1, 0, -1, 1), list),
+    ((4, 2, 3), (2, 0, -2, 3), tuple),
+    ((4, 2, 4), (1, 0, -1, 2), np.ndarray),
+    ((4, 3, 0), (5, 2, -7, 0), list),
+    ((4, 3, 1), (5, 2, -7, 3), tuple),
+    ((4, 3, 2), (5, 2, -7, 6), np.ndarray),
+    ((4, 3, 3), (5, 2, -7, 9), list),
+    ((4, 3, 4), (5, 2, -7, 12), tuple),
+    ((4, 4, 0), (1, 1, -2, 0), np.ndarray),
+    ((4, 4, 1), (4, 4, -8, 3), list),
+    ((4, 4, 2), (2, 2, -4, 3), tuple),
+    ((4, 4, 3), (4, 4, -8, 9), np.ndarray),
+    ((4, 4, 4), (1, 1, -2, 3), list),
+    # Placeholder for copying for if we want to add more
+    # ((), (), list),
+    # ((), (), tuple),
+    # ((), (), np.ndarray),
+)
+
+
+@pytest.mark.parametrize("test_params", vector_indices_test_matrix)
+def test_vector_indices_3_to_4(
+    test_params: tuple[tuple[int, ...], tuple[int, ...], type],
+):
+    # Unpack test parameters
+    m_indices, mb_indices, input_type = test_params
+
+    # Convert input indices (M indices) to correct type
+    if input_type == np.ndarray:
+        input_value = np.array(m_indices)
+    else:
+        input_value = input_type(m_indices)
+
+    # Check that object conversion has worked
+    assert isinstance(input_value, input_type)
+
+    # Run the function
+    assert_equal(
+        vector_indices_3_to_4(input_value),
+        np.array(mb_indices) / np.gcd.reduce(mb_indices),
+    )
+
+
+@pytest.mark.parametrize("test_params", vector_indices_test_matrix)
+def test_vector_indices_4_to_3(
+    test_params: tuple[tuple[int, ...], tuple[int, ...], type],
+):
+    # Unpack test parameters
+    m_indices, mb_indices, input_type = test_params
+
+    # Convert input indices (MB indices) to correct type
+    if input_type == np.ndarray:
+        input_value = np.array(mb_indices)
+    else:
+        input_value = input_type(mb_indices)
+
+    # Check that object conversion has worked
+    assert isinstance(input_value, input_type)
+
+    # Run the function
+    assert_equal(
+        vector_indices_4_to_3(input_value),
+        (np.array(m_indices) / np.gcd.reduce(m_indices)),
+    )


### PR DESCRIPTION
Previously, we discovered that conversions between Miller and Miller-Bravais indices for planes and vectors followed different mathematical operations (see [crystallographic calculator)(https://ssd.phys.strath.ac.uk/resources/crystallography/crystallographic-direction-calculator/)).

This PR corrects the functions so that the Miller and Miller-Bravais interconversions for planar and vector indices are implemented correctly, and adds a comprehensive but fast series of tests to ensure that the conversions are done correctly.