### PR TITLE
Set tests to trigger on pushes to 'main' and 'dev', in addition to PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,8 @@ name: Build and test package
 on:
   push:
     branches:
-      - master # Trigger on pushes to master branch
+      - main # Trigger on pushes to master branch
+      - dev
   pull_request:
     branches:
       - "**" # Trigger on PRs of ANY branch


### PR DESCRIPTION
A couple of things here:
* I have renamed the `master` branch to `main`, to keep it in line with the naming conventions of modern repos.
* I have set the GitHub workflows to trigger on pushes to both the `main` and `dev` branches, seeing as the plan is to keep updating the public-facing and the development branch in parallel.