### PR TITLE
Add tests for 'cpf.util.io'

### DIFF
--- a/Example1-Fe/BCC1_Dioptas_input.py
+++ b/Example1-Fe/BCC1_Dioptas_input.py
@@ -23,9 +23,9 @@ Calib_mask     = "DiffractionMask_Dioptas.mask"
 Output_directory   = 'results'
 Output_type        = ['Polydefix', 'DifferentialStrain', 'FitMovie', 'CoefficientTable', 'CollectionMovie']
 
-metadata_labels = {#"time": "time_start",
-                   "exposure": "Exposure_time"}
-metadata = ['Exposure_time', 'Exposure_period']
+# metadata_labels = {#"time": "time_start",
+#                    "exposure": "Exposure_time"}
+# metadata = ['Exposure_time', 'Exposure_period']
 
 
 # define ranges and peaks
@@ -81,11 +81,11 @@ fit_orders = [
 ]
 
 
-# import fabio
-def metadata_read_func(settings, image_obj, **kwargs):
-    out = image_obj.header
-    out["Exposure_time"] = float(out["Exposure_time"][:-2])
-    out["Exposure_period"] = float(out["Exposure_period"][:-2])
-    out['namename'] = image_obj.filename
-    return out
+# # import fabio
+# def metadata_read_func(settings, image_obj, **kwargs):
+#     out = image_obj.header
+#     out["Exposure_time"] = float(out["Exposure_time"][:-2])
+#     out["Exposure_period"] = float(out["Exposure_period"][:-2])
+#     out['namename'] = image_obj.filename
+#     return out
     

--- a/src/cpf/Cascade.py
+++ b/src/cpf/Cascade.py
@@ -57,8 +57,8 @@ from cpf.data_preprocess import remove_cosmics as cosmicsimage_preprocess
 from cpf.settings import Settings
 from cpf.util.io import (
     has_value,
-    json_numpy_serializer,
     make_outfile_name,
+    numpy_to_json,
     peak_string,
     title_file_names,
 )
@@ -440,7 +440,7 @@ def execute(
                     TempFile,
                     sort_keys=True,
                     indent=2,
-                    default=json_numpy_serializer,
+                    default=numpy_to_json,
                 )
 
             # if propagating the fits write them to a temporary file
@@ -453,7 +453,7 @@ def execute(
                         TempFile,
                         sort_keys=True,
                         indent=2,
-                        default=json_numpy_serializer,
+                        default=numpy_to_json,
                     )
 
     if parallel is True:

--- a/src/cpf/Cascade.py
+++ b/src/cpf/Cascade.py
@@ -54,19 +54,18 @@ from scipy.signal import find_peaks
 import cpf.XRD_FitPattern as XRD_FitPattern
 from cpf.BrightSpots import SpotProcess
 from cpf.data_preprocess import remove_cosmics as cosmicsimage_preprocess
-from cpf.IO_functions import (
+from cpf.settings import Settings
+from cpf.util.io import (
     any_terms_null,
     json_numpy_serializer,
     make_outfile_name,
     peak_string,
     title_file_names,
 )
-from cpf.settings import Settings
 from cpf.util.logging import get_logger
 from cpf.XRD_FitSubpattern import fit_sub_pattern
 
 logger = get_logger("cpf.Cascade")
-
 
 
 def initiate(*args, **kwargs):
@@ -119,7 +118,6 @@ def execute(
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-
     show_plots: bool = False,
     **kwargs,
 ):

--- a/src/cpf/Cascade.py
+++ b/src/cpf/Cascade.py
@@ -56,7 +56,7 @@ from cpf.BrightSpots import SpotProcess
 from cpf.data_preprocess import remove_cosmics as cosmicsimage_preprocess
 from cpf.settings import Settings
 from cpf.util.io import (
-    any_terms_null,
+    has_value,
     json_numpy_serializer,
     make_outfile_name,
     peak_string,
@@ -277,7 +277,7 @@ def execute(
             # But does it need to?
             tth_range = settings_for_fit.subfit_orders["range"]
             if settings_for_fit.cascade_track is True and "previous_fit" in locals():
-                null_terms = any_terms_null(params, val_to_find=None)
+                null_terms = has_value(params, val=None)
                 if null_terms == True:
                     # the previous fit has problems so discard it
                     logger.info(

--- a/src/cpf/XRD_FitPattern.py
+++ b/src/cpf/XRD_FitPattern.py
@@ -27,8 +27,8 @@ from cpf.series_functions import get_series_mean
 from cpf.settings import Settings, get_settings, is_settings
 from cpf.util.io import (
     has_value,
-    json_numpy_serializer,
     make_outfile_name,
+    numpy_to_json,
     peak_string,
     title_file_names,
 )

--- a/src/cpf/XRD_FitPattern.py
+++ b/src/cpf/XRD_FitPattern.py
@@ -4,10 +4,10 @@ from __future__ import annotations  # Enables additional Python features
 
 __all__ = ["execute", "write_output"]
 
+import inspect
 import json
 import logging
 import sys
-import inspect
 from importlib import import_module
 from os import cpu_count
 from pathlib import Path
@@ -22,16 +22,16 @@ from pathos.pools import ParallelPool
 from cpf import output_formatters
 from cpf.BrightSpots import SpotProcess
 from cpf.data_preprocess import remove_cosmics as cosmicsimage_preprocess
-from cpf.IO_functions import (
+from cpf.output_formatters.fits_io import ReadFits_to_list, WriteFits
+from cpf.series_functions import get_series_mean
+from cpf.settings import Settings, get_settings, is_settings
+from cpf.util.io import (
     any_terms_null,
     json_numpy_serializer,
     make_outfile_name,
     peak_string,
     title_file_names,
 )
-from cpf.output_formatters.fits_io import WriteFits, ReadFits_to_list
-from cpf.series_functions import get_series_mean
-from cpf.settings import Settings, is_settings, get_settings
 from cpf.util.logging import get_logger, set_global_log_level
 from cpf.XRD_FitSubpattern import fit_sub_pattern
 
@@ -44,9 +44,9 @@ np.set_printoptions(threshold=sys.maxsize)
 logger = get_logger("cpf.XRD_FitPattern")
 
 
-
-__doc__ = "This is the main function for fitting the diffraction (or dispersed) peak data. "
-
+__doc__ = (
+    "This is the main function for fitting the diffraction (or dispersed) peak data. "
+)
 
 
 def register_default_formats() -> dict[str, ModuleType]:
@@ -97,47 +97,48 @@ def initiate(
         setting_type = "dictionary"
     elif isinstance(settings, str) or isinstance(settings, Path):
         running_name = settings
-        setting_type = "file" #assume string deontes file name
-    elif is_settings(settings): #isinstance(settings, type(Settings()))
+        setting_type = "file"  # assume string deontes file name
+    elif is_settings(settings):  # isinstance(settings, type(Settings()))
         setting_type = "class"
         if settings.settings_file is not None:
-            #there is a file name or run label in the settings class
+            # there is a file name or run label in the settings class
             running_name = settings.settings_file
         else:
-            running_name = "cpf settings class"     
-    else: #unknown
+            running_name = "cpf settings class"
+    else:  # unknown
         setting_type = "Unknown"
-        running_name = "cpf_run"     
+        running_name = "cpf_run"
     log_file = log_file = make_outfile_name(
         base_filename=running_name, extension=".log", overwrite=True
     )
     logger.add_file_handler(log_file)
 
     # make a header in the log file so that we know where the processing starts
-    # It is the first pass through the method if: 
+    # It is the first pass through the method if:
     # 1. if settings is not a settings class then it has to be new.
     # 2. if it is a settings class and is not validated then is likely to be new
-    # 3. but it could be a validated settings class and also new executeion. 
+    # 3. but it could be a validated settings class and also new executeion.
     #       but in normal use this will not be the case. Therefore can ignore for now.
-    #       and if the settings class has been validated then it will appear in the log 
+    #       and if the settings class has been validated then it will appear in the log
     #       file as an initiation or validation.
-    # all calls to the methods in here pass around a settings class once it is made and 
+    # all calls to the methods in here pass around a settings class once it is made and
     # so is_settings == True.
-    if (not is_settings(settings) or 
-        (is_settings(settings) and settings.is_valid()==False)
-        ): 
+    if not is_settings(settings) or (
+        is_settings(settings) and settings.is_valid() == False
+    ):
         logger.info("")
         logger.info("=================================================================")
         logger.info("")
-        logger.info(f"Starting data proceesing using settings {setting_type}{' from' if setting_type != 'file' else ''}: {running_name}")    
+        logger.info(
+            f"Starting data proceesing using settings {setting_type}{' from' if setting_type != 'file' else ''}: {running_name}"
+        )
         logger.info("")
         logger.info("=================================================================")
         logger.info("")
-        
-    settings_class = get_settings(settings, **kwargs)
-    
-    return settings_class
 
+    settings_class = get_settings(settings, **kwargs)
+
+    return settings_class
 
 
 def view(
@@ -155,7 +156,7 @@ def view(
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-    **kwargs
+    **kwargs,
 ):
     """
     :param settings:
@@ -171,16 +172,18 @@ def view(
     :param kwargs:
     :return:
     """
-    
+
     settings_class = initiate(settings, report=report, **kwargs)
     # make a note in the logger.
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "view":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.view with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.view with settings: {settings_class.settings_file}"
+        )
         logger.info("")
 
     # view the listed file only
@@ -189,7 +192,7 @@ def view(
         settings_class.set_data_files(keep=pattern)
 
     write_output(settings_class, out_type="CollectionMovie", **kwargs)
-    
+
     # write_output(settings_file=settings_file, out_type="RangesMovie")
 
     # execute(
@@ -218,7 +221,7 @@ def set_range(
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-    **kwargs
+    **kwargs,
 ):
     """
     :param settings:
@@ -238,14 +241,16 @@ def set_range(
     settings_class = initiate(settings, report=report, **kwargs)
     # make a note in the logger.
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "set_range":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.set_range with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.set_range with settings: {settings_class.settings_file}"
+        )
         logger.info("")
-    
+
     # search over the first file only
     # restrict file list to first file
     settings_class.set_data_files(keep=0)
@@ -253,7 +258,7 @@ def set_range(
     settings_class.set_subpatterns(subpatterns=subpattern)
     # circulment revalidating the settings class
     settings_class._unmodified_self = settings_class._validation_copy()
-    
+
     execute(
         settings_class,
         debug=debug,
@@ -280,7 +285,7 @@ def initial_peak_position(
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-    **kwargs
+    **kwargs,
 ):
     """
     Calls interactive graph to set the inital peak postion guesses.
@@ -301,18 +306,20 @@ def initial_peak_position(
     :param kwargs:
     :return:
     """
-    
+
     settings_class = initiate(settings, report=report, **kwargs)
     # make a note in the logger.
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "initial_peak_position":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.initial_peak_position with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.initial_peak_position with settings: {settings_class.settings_file}"
+        )
         logger.info("")
-    
+
     # search over the first file only
     settings_class.set_data_files(keep=0)
     # restrict to sub-patterns listed
@@ -321,7 +328,9 @@ def initial_peak_position(
     settings_class._unmodified_self = settings_class._validation_copy()
 
     logger.info("\n'initial_peak_position' needs an interactive matplotlib figure.")
-    logger.info("If you are using sypder with inline figures, call '%matplotlib qt', then rerun the script")
+    logger.info(
+        "If you are using sypder with inline figures, call '%matplotlib qt', then rerun the script"
+    )
     logger.info("To restore the inline plotting afterwards call '%matplotlib inline'")
     logger.info("To move to the next peak selection close the window.\n")
 
@@ -334,7 +343,7 @@ def initial_peak_position(
         parallel=parallel,
         mode="set-guess",
         report=report,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -440,21 +449,21 @@ def order_search(
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-    **kwargs
+    **kwargs,
 ):
     """
     Searches for the best order to use for 'search_parameter', where 'search_over'
-    is one of the model parameters (e.g. 'background', 'width', etc). 
+    is one of the model parameters (e.g. 'background', 'width', etc).
     The data is fit with orders in the range defined by 'search_over'.
     The resultant fits are plotted by cpf.output_formatters.WriteOrderSearchFigures
-    
+
     Makes a json file with all the fits that is named:
         *settings_file*__search=*search_parameter*_subpattern=*subpattern*_peak=*search_peak*
 
-    The function will technically work in parallel but due to memory limitations 
-    and the way the code is structured, it is set by default to run this function in 
-    series. 
-    For the same reason, althogh the code can run 'all' the peaks at once, it is 
+    The function will technically work in parallel but due to memory limitations
+    and the way the code is structured, it is set by default to run this function in
+    series.
+    For the same reason, althogh the code can run 'all' the peaks at once, it is
     split up and loops over each peak separately.
 
 
@@ -489,34 +498,35 @@ def order_search(
     None.
 
     """
-    
+
     settings_class = initiate(settings, report=report, **kwargs)
     # make a note in the logger.
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "order_search":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.order_search with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.order_search with settings: {settings_class.settings_file}"
+        )
         logger.info("")
 
     # search over the first file only
     settings_class.set_data_files(keep=0)
     settings_class.fit_propagate = False
-    
+
     # loop over the peaks in turn unless forced
-    if subpattern =="force all":
+    if subpattern == "force all":
         subpattern = ["all"]
-    elif subpattern =="all":
+    elif subpattern == "all":
         subpattern = list(range(len(settings_class.fit_orders)))
     elif not isinstance(subpattern, list):
         subpattern = [subpattern]
 
     for i in range(len(subpattern)):
-
         logger.info(f"Performing order_search for peak {i}")
-        
+
         # set search orders and execute
         settings_class.set_order_search(
             search_parameter=search_parameter,
@@ -536,7 +546,7 @@ def order_search(
         )
         # circulment revalidating the settings class
         settings_class._unmodified_self = settings_class._validation_copy()
-        
+
         execute(
             settings_class,
             refine=refine,
@@ -545,14 +555,14 @@ def order_search(
             parallel=parallel,
             report=report,
         )
-    
+
         # call WriteOrderSearchFigures to make the figures.
         write_output(
             settings_class,
             debug=True,
             out_type="OrderSearchFigures",
         )
-        
+
         write_output(
             settings_class,
             debug=True,
@@ -561,6 +571,7 @@ def order_search(
 
         settings_class.unset_order_search()
     logger.info("Order searches are completed.")
+
 
 def write_output(
     settings,
@@ -576,7 +587,7 @@ def write_output(
     **kwargs,
 ):
     """
-    
+
     :param settings : *.py file, string, Path or cpf Settings
     :param debug:
     :param fit_parameters:
@@ -588,16 +599,18 @@ def write_output(
     :param det:
     :return:
     """
-    
+
     settings_class = initiate(settings, report=report, **kwargs)
     # make a note in the logger.
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "write_output":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.write_output with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.write_output with settings: {settings_class.settings_file}"
+        )
         logger.info("")
 
     if out_type is not None:
@@ -605,7 +618,9 @@ def write_output(
         settings_class.set_output_types(out_type_list=out_type)
 
     if settings_class.output_types is None:
-        logger.warning("There are no output types. Add 'Output_type' to input file or specify 'out_type' in command.")
+        logger.warning(
+            "There are no output types. Add 'Output_type' to input file or specify 'out_type' in command."
+        )
     else:
         for mod in settings_class.output_types:
             logger.info(" ".join(map(str, [("Writing output file(s) using %s" % mod)])))
@@ -654,20 +669,22 @@ def execute(
     :param iterations:
     :return:
     """
-    
+
     # if not is_settings(settings):
     settings_class = initiate(settings, report=report, **kwargs)
     # make note in logger
     # suppress output if called by another module.
-    for i in range(len(inspect.stack())-1,-1,-1):
-        if inspect.stack()[i].function == "<module>":          
-            base_call = inspect.stack()[i-1].function
+    for i in range(len(inspect.stack()) - 1, -1, -1):
+        if inspect.stack()[i].function == "<module>":
+            base_call = inspect.stack()[i - 1].function
     if base_call == "execute":
         logger.info("")
-        logger.info(f"Running: XRD_FitPattern.execute with settings: {settings_class.settings_file}")
+        logger.info(
+            f"Running: XRD_FitPattern.execute with settings: {settings_class.settings_file}"
+        )
         logger.info("")
-    
-    #get data from settings class
+
+    # get data from settings class
     new_data = settings_class.data_class
 
     # Define locally required names
@@ -678,14 +695,16 @@ def execute(
         overwrite=True,
     )
 
-    as_masked = kwargs.pop('as_masked', False)
-    if (mode == "set-range" or mode == "view"):
+    as_masked = kwargs.pop("as_masked", False)
+    if mode == "set-range" or mode == "view":
         as_masked = True
     else:
         as_masked = as_masked
         if as_masked == True:
-            logger.warning("'as_masked'==True changes the fit for some masked datasts. I dont know why. Check fits with and without this setting")
-        
+            logger.warning(
+                "'as_masked'==True changes the fit for some masked datasts. I dont know why. Check fits with and without this setting"
+            )
+
     if settings_class.calibration_data:
         data_to_fill = Path(settings_class.calibration_data).resolve()
     else:
@@ -727,7 +746,9 @@ def execute(
     # for j in range(settings_class.image_number):
     progress = proglog.default_bar_logger("bar")  # shorthand to generate a bar logger
     for j in progress.iter_bar(image=range(settings_class.image_number)):
-        logger.info(f"Processing {title_file_names(image_name=settings_class.image_list[j])}")
+        logger.info(
+            f"Processing {title_file_names(image_name=settings_class.image_list[j])}"
+        )
 
         settings_class.set_subpattern(j, 0)
 
@@ -746,28 +767,44 @@ def execute(
             extension=".json",
             overwrite=True,
         )
-        
+
         # if the output file already exists and resume is true then skip
-        # this iteration        
+        # this iteration
         if resume == True and Path(filename).is_file():
-            logger.info(f"  {title_file_names(image_name=settings_class.image_list[j])} has already been processed -- skipping")
+            logger.info(
+                f"  {title_file_names(image_name=settings_class.image_list[j])} has already been processed -- skipping"
+            )
             continue
         # else do the process.
 
-        if ((isinstance(settings_class.datafile_preprocess, dict) ) or #settings_class.datafile_preprocess is not None or 
-            (isinstance(settings_class.calibration_mask, dict) and "threshold" in settings_class.calibration_mask)
-            ):
+        if (
+            (
+                isinstance(settings_class.datafile_preprocess, dict)
+            )  # settings_class.datafile_preprocess is not None or
+            or (
+                isinstance(settings_class.calibration_mask, dict)
+                and "threshold" in settings_class.calibration_mask
+            )
+        ):
             # needed because image preprocessing adds to the mask and is different for each image.
-            # set intenstiy threshold and/or cosmics for each frame. 
+            # set intenstiy threshold and/or cosmics for each frame.
             # only applies these because all other mask functions are static.
             new_data.mask_restore()
-            if (isinstance(settings_class.datafile_preprocess, dict) and "cosmics" in settings_class.datafile_preprocess):
+            if (
+                isinstance(settings_class.datafile_preprocess, dict)
+                and "cosmics" in settings_class.datafile_preprocess
+            ):
                 new_data = cosmicsimage_preprocess(new_data, settings_class)
-            if (isinstance(settings_class.calibration_mask, dict) and "threshold" in settings_class.calibration_mask):
-                # set intenstiy threshold for each frame. 
+            if (
+                isinstance(settings_class.calibration_mask, dict)
+                and "threshold" in settings_class.calibration_mask
+            ):
+                # set intenstiy threshold for each frame.
                 # only applies to threshold because all other mask functions are static
                 # (cannot change between frames)
-                new_data.set_mask(intensity_bounds = settings_class.calibration_mask["threshold"])
+                new_data.set_mask(
+                    intensity_bounds=settings_class.calibration_mask["threshold"]
+                )
         else:
             # nothing is done here.
             pass
@@ -801,7 +838,7 @@ def execute(
                 filename = make_outfile_name(
                     settings_class.image_list[j],
                     directory=settings_class.output_directory,
-                    additional_text = "integrated",
+                    additional_text="integrated",
                     extension=".png",
                     overwrite=True,
                 )
@@ -828,7 +865,7 @@ def execute(
                 del previous_fit
 
         # Switch to save the first fit in each sequence.
-        save_figs = False#True if (j == 0 or save_all is True) else False
+        save_figs = False  # True if (j == 0 or save_all is True) else False
 
         # Pass each sub-pattern to Fit_Subpattern for fitting in turn.
         fitted_param = []
@@ -836,7 +873,6 @@ def execute(
         parallel_pile = []
 
         for i in range(len(settings_class.fit_orders)):
-            
             if parallel == False:
                 serial_string = f"Fitting range {i+1}/{len(settings_class.fit_orders)}"
                 logger.info(serial_string)
@@ -876,7 +912,7 @@ def execute(
                     tth_range = previous_fit[i]["range"][0]
                     mid = []
                     for k in range(len(params["peak"])):
-                        mid.append(get_series_mean(params['peak'][k], "d-space"))
+                        mid.append(get_series_mean(params["peak"][k], "d-space"))
 
                     if mid == None or mid == 0:
                         # the previous fits failed in some way.
@@ -921,7 +957,9 @@ def execute(
                     # re-get settings for current subpattern
                     settings_class.set_subpattern(j, i)
 
-            sub_data = new_data.duplicate_without_detector(range_bounds=tth_range, as_masked=as_masked)
+            sub_data = new_data.duplicate_without_detector(
+                range_bounds=tth_range, as_masked=as_masked
+            )
 
             # Mask the subpattern by intensity if called for
             if (
@@ -955,11 +993,12 @@ def execute(
                 ax = fig.add_subplot(1, 1, 1)
                 ax_o1 = plt.subplot(111)
                 sub_data.plot_calibrated(
-                    fig_plot=fig, axis_plot=ax, show="intensity", **kwargs #rastered="scatter"
+                    fig_plot=fig,
+                    axis_plot=ax,
+                    show="intensity",
+                    **kwargs,  # rastered="scatter"
                 )
-                plt.suptitle(
-                    peak_string(settings_class.subfit_orders) + "; calibrated"
-                )
+                plt.suptitle(peak_string(settings_class.subfit_orders) + "; calibrated")
 
                 filename = make_outfile_name(
                     settings_class.image_list[j],
@@ -983,8 +1022,11 @@ def execute(
                 ax = fig_1.add_subplot(1, 1, 1)
                 ax_o1 = plt.subplot(111)
                 sub_data.plot_calibrated(
-                    fig_plot=fig_1, axis_plot=ax, y_axis="azimuth", limits=[0, 100],
-                    **kwargs
+                    fig_plot=fig_1,
+                    axis_plot=ax,
+                    y_axis="azimuth",
+                    limits=[0, 100],
+                    **kwargs,
                 )
                 plt.title(peak_string(settings_class.subfit_orders))
 
@@ -1044,7 +1086,7 @@ def execute(
                         min_data_intensity=settings_class.fit_min_data_intensity,
                         min_peak_intensity=settings_class.fit_min_peak_intensity,
                         fit_method=fit_method,
-                        **kwargs
+                        **kwargs,
                     )
                     fitted_param.append(tmp)
 
@@ -1054,26 +1096,28 @@ def execute(
                 tmp = pool.map(parallel_processing, parallel_pile)
                 for i in range(len(settings_class.fit_orders)):
                     fitted_param.append(tmp[i])
-            
+
             # store the fit parameters' information as a JSON file.
             WriteFits(settings_class, fitted_param, data_class=new_data, mode=mode)
 
             # if propagating the fits write them to a temporary file
             if settings_class.fit_propagate:
-                WriteFits(settings_class, fitted_param, filename_to_write=temporary_data_file)
+                WriteFits(
+                    settings_class, fitted_param, filename_to_write=temporary_data_file
+                )
 
     if mode == "fit":
         # Write the output files.
-        write_output(
-            settings_class, debug=debug
-        )
+        write_output(settings_class, debug=debug)
 
     if parallel is True:
         pool.clear()
 
+
 def parallel_processing(p):
     a, kw = p
     return fit_sub_pattern(*a, **kw)
+
 
 if __name__ == "__main__":
     # Load settings fit settings file.

--- a/src/cpf/XRD_FitPattern.py
+++ b/src/cpf/XRD_FitPattern.py
@@ -26,7 +26,7 @@ from cpf.output_formatters.fits_io import ReadFits_to_list, WriteFits
 from cpf.series_functions import get_series_mean
 from cpf.settings import Settings, get_settings, is_settings
 from cpf.util.io import (
-    any_terms_null,
+    has_value,
     json_numpy_serializer,
     make_outfile_name,
     peak_string,
@@ -891,7 +891,7 @@ def execute(
             # But does it need to?
             tth_range = np.array(settings_class.subfit_orders["range"])
             if settings_class.fit_track is True and "previous_fit" in locals():
-                null_terms = any_terms_null(params, val_to_find=None)
+                null_terms = has_value(params, val=None)
                 if null_terms == True:
                     # the previous fit has problems so discard it
                     logger.moreinfo(  # type: ignore

--- a/src/cpf/XRD_FitSubpattern.py
+++ b/src/cpf/XRD_FitSubpattern.py
@@ -20,7 +20,7 @@ import cpf.peak_functions as pf
 import cpf.series_constraints as sc
 import cpf.series_functions as sf
 from cpf.fitsubpattern_chunks import fit_chunks, fit_series
-from cpf.IO_functions import (
+from cpf.util.io import (
     any_errors_huge,
     any_terms_null,
     json_numpy_serializer,
@@ -96,7 +96,9 @@ def update_previous_params_from_orders(peeks, previous_params, orders):
         for param in choice_list:
             coeff_type = sf.get_params_type(previous_params, param, peak=y)
             coeff_type = sf.coefficient_type_as_number(coeff_type)
-            if coeff_type != sf.coefficient_types()["independent"]:  # if parameters are not independent
+            if (
+                coeff_type != sf.coefficient_types()["independent"]
+            ):  # if parameters are not independent
                 if sc.BiggestValue(orders["peak"][y][param]) > sf.get_order_from_params(
                     previous_params["peak"][y][param]
                 ):
@@ -108,9 +110,9 @@ def update_previous_params_from_orders(peeks, previous_params, orders):
                     previous_params["peak"][y][param] = (
                         previous_params["background"][y] + [0] * change_by
                     )
-                elif sc.BiggestValue(orders["peak"][y][param]) < sf.get_order_from_params(
-                    previous_params["peak"][y][param]
-                ):
+                elif sc.BiggestValue(
+                    orders["peak"][y][param]
+                ) < sf.get_order_from_params(previous_params["peak"][y][param]):
                     change_by = (
                         np.size(previous_params["peak"][y][param])
                         - np.max(orders["peak"][y][param]) * 2
@@ -126,7 +128,8 @@ def update_previous_params_from_orders(peeks, previous_params, orders):
 
     # loop for background orders/size
     if (
-        sf.get_params_type(previous_params, "background") != sf.coefficient_types()["independent"]
+        sf.get_params_type(previous_params, "background")
+        != sf.coefficient_types()["independent"]
     ):  # if parameters are not independent
         for y in range(
             np.max([len(orders["background"]), len(previous_params["background"])])
@@ -198,7 +201,7 @@ def check_num_azimuths(peeks, azimu, orders):
             coeff_type = sf.coefficient_type_as_number(
                 sf.get_params_type(orders, param, peak=y)
             )
-            if coeff_type != sf.coefficient_types(full=True)["independent"]["num"]:  
+            if coeff_type != sf.coefficient_types(full=True)["independent"]["num"]:
                 # if parameters are not independent
                 max_coeff = np.max(
                     [max_coeff, sf.get_number_coeff(orders, param, peak=y)]
@@ -257,7 +260,7 @@ def fit_sub_pattern(
     # set a limit to the maximum number of function evaluations.
     # make variable in case need more iterations for other data
     default_max_f_eval = 400
-    max_f_eval =  default_max_f_eval
+    max_f_eval = default_max_f_eval
 
     # Measure the elapsed time during fitting.
     # To help decide what is bad fit or if over fitting the data.
@@ -296,10 +299,14 @@ def fit_sub_pattern(
         # check if the previous fit was 'good' i.e. constrains no 'null' values.
         # N.B. null values in json file are read in as None
         any_bad_vals = any_terms_null(previous_params, val_to_find=None)
-        any_bad_vals = any_errors_huge(previous_params, large_errors=large_errors, any_huge=any_bad_vals)
+        any_bad_vals = any_errors_huge(
+            previous_params, large_errors=large_errors, any_huge=any_bad_vals
+        )
         if any_bad_vals == True:
             # the previous fit has problems so discard it
-            logger.moreinfo("Propagated fit has problems so discarding it and doing fit from scratch")
+            logger.moreinfo(
+                "Propagated fit has problems so discarding it and doing fit from scratch"
+            )
             previous_params = None
 
     if previous_params:
@@ -321,12 +328,14 @@ def fit_sub_pattern(
             np.min(fit_centroid) < settings_as_class.subfit_orders["range"][0]
             or np.min(fit_centroid) > settings_as_class.subfit_orders["range"][1]
         ):
-            logger.moreinfo("Fitted d-spacing limits are out of bounds; discarding the fit and starting again.")
+            logger.moreinfo(
+                "Fitted d-spacing limits are out of bounds; discarding the fit and starting again."
+            )
             previous_params = None
 
     # initiate counter for while loop.
     if previous_params is None or previous_params == [] or previous_params is False:
-        previous_params = None # make sure expected value for later
+        previous_params = None  # make sure expected value for later
         step = [0]
     else:
         step = [5]
@@ -352,15 +361,17 @@ def fit_sub_pattern(
         if step[-1] <= 9:
             # generate chunks and initial fits
             # or parse previous fits into correct data structure
-                
+
             # Measure the time taken to do the chunks, the elapsed time during fitting.
             # To help decide which is the best peak parameters.
             chunks_start = time.time()
-            
+
             # check if the data intensity is above threshold.
             if np.max(data_as_class.intensity) <= min_data_intensity:
                 # then there is likely no determinable peak in the data
-                logger.moreinfo(f"Not sufficient intensity in the data to proceed with fitting (I_max < {min_data_intensity}).")
+                logger.moreinfo(
+                    f"Not sufficient intensity in the data to proceed with fitting (I_max < {min_data_intensity})."
+                )
                 # set step to -21 so that it is still negative at the end
                 step.append(-21)  # get to the end and void the fit
                 # void so send empty parameter set to out.
@@ -465,7 +476,9 @@ def fit_sub_pattern(
 
                 if np.max(ave_intensity) <= min_peak_intensity:
                     # then there is no determinable peak(s) in the data
-                    logger.moreinfo(f"Not sufficient intensity in the chunked peaks to proceed with fitting (h_max < {min_peak_intensity}).")
+                    logger.moreinfo(
+                        f"Not sufficient intensity in the chunked peaks to proceed with fitting (h_max < {min_peak_intensity})."
+                    )
                     # set step to -11 so that it is still negative at the end
                     step.append(-11)  # get to the end and void the fit
                     # void so send empty parameter set to out.
@@ -476,7 +489,9 @@ def fit_sub_pattern(
                     )
 
             elif step[-1] >= 0 and previous_params:
-                logger.moreinfo("Using previously fitted parameters and propagating fit")
+                logger.moreinfo(
+                    "Using previously fitted parameters and propagating fit"
+                )
                 # FIX ME: This should load the saved lmfit Parameter class object.
                 # Need to initiate usage (save and load).
                 # For now have propagated use of new_params so re-instantiate the master_params object below,
@@ -658,8 +673,12 @@ def fit_sub_pattern(
 
                 if np.max(ave_intensity) <= min_peak_intensity:
                     # then there is no determinable peak in the data
-                    logger.moreinfo("Not sufficient intensity in the chunked peaks to proceed with fitting.")
-                    logger.moreinfo(f"most inense chunk {np.max(ave_intensity)} <= min allowed peak intensity {min_peak_intensity}")
+                    logger.moreinfo(
+                        "Not sufficient intensity in the chunked peaks to proceed with fitting."
+                    )
+                    logger.moreinfo(
+                        f"most inense chunk {np.max(ave_intensity)} <= min allowed peak intensity {min_peak_intensity}"
+                    )
                     # logger.moreinfo("Not sufficient intensity in the chunked peaks to proceed with fitting.")
                     # set step to -101 so that it is still negative at the end
                     step.append(-101)  # get to the end and void the fit
@@ -730,14 +749,17 @@ def fit_sub_pattern(
             if (
                 fout.success is True
                 and previous_params != None
-                and  any_errors_huge(
+                and any_errors_huge(
                     lmm.params_to_new_params(
                         master_params, orders=settings_as_class.subfit_orders
                     ),
                     large_errors=large_errors,
-                ) == True
+                )
+                == True
             ):
-                logger.moreinfo("The fitting worked, but propagated params could have lead to rubbish fits (huge errors). Try again.")
+                logger.moreinfo(
+                    "The fitting worked, but propagated params could have lead to rubbish fits (huge errors). Try again."
+                )
                 step.append(0)
                 # clear previous_params so we can't get back here
                 previous_params = None
@@ -746,11 +768,13 @@ def fit_sub_pattern(
                 and previous_params != None
                 and any_terms_null(master_params, val_to_find=None) == True
             ):
-                logger.moreinfo("The fitting worked, but propagated params could have lead to rubbish fits (null values). Try again.")
+                logger.moreinfo(
+                    "The fitting worked, but propagated params could have lead to rubbish fits (null values). Try again."
+                )
                 step.append(0)
                 # clear previous_params so we can't get back here
                 previous_params = None
-            elif fout.success: #True
+            elif fout.success:  # True
                 # it worked, errors are not massive, carry on
                 step.append(step[-1] + 100)
                 master_params = fout.params
@@ -767,19 +791,19 @@ def fit_sub_pattern(
                 step.append(step[-1] - 9)
                 max_f_eval = np.inf
             elif step[-1] == 28 and fout.success == 0:
-                # we tried all the way with the previous fits. 
+                # we tried all the way with the previous fits.
                 # get rid of them and start again
                 step.append(0)
                 previous_params = None
-            else: #23,24,29 and other values >=30
+            else:  # 23,24,29 and other values >=30
                 err_str = "The value of step here should not be achievable. Oops. \n The data is not fitting. Discard."
                 logger.critical(" ".join(map(str, [(err_str)])))
                 step.append(step[-1] - 200)
-        
-        if 0: #report_status:
-            print(f"    status: step = {step}")  
+
+        if 0:  # report_status:
+            print(f"    status: step = {step}")
             print(f"        time elaspsed = {time.time() - t_start}")
-        
+
         if step[-1] < 0:
             # the fit is void and we need to exit.
             # make sure all the height values are nan so that we dont propagate rubbish
@@ -889,39 +913,86 @@ def fit_sub_pattern(
                 }
             }
         )
-        new_params.update({'data_ranges':{
-                'data':{
-                    "max": np.max(ma.filled(data_as_class.intensity, np.nan)),
-                    "min": np.min(ma.filled(data_as_class.intensity, np.nan)),
-                    "pt1percentile": np.nanpercentile(ma.filled(data_as_class.intensity, np.nan), 0.1, method='closest_observation'),
-                    "1percentile":   np.nanpercentile(ma.filled(data_as_class.intensity, np.nan), 1, method='closest_observation'),
-                    "99percentile":    np.nanpercentile(ma.filled(data_as_class.intensity, np.nan), 99, method='closest_observation'),
-                    "99pt9percentile": np.nanpercentile(ma.filled(data_as_class.intensity, np.nan), 99.9, method='closest_observation'),
-                },
-                'model':{
-                    "max": np.max(fout.best_fit),
-                    "min": np.min(fout.best_fit),
-                    "pt1percentile": np.nanpercentile(fout.best_fit, 0.1, method='closest_observation'),
-                    "1percentile": np.nanpercentile(fout.best_fit, 1, method='closest_observation'),
-                    "99percentile": np.nanpercentile(fout.best_fit, 99, method='closest_observation'),
-                    "99pt9percentile": np.nanpercentile(fout.best_fit, 99.9, method='closest_observation'),
-                },
-                'residuals':{
-                    "max": np.max(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit),
-                    "min": np.min(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit),
-                    "pt1percentile": np.nanpercentile(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit, 0.1, method='closest_observation'),
-                    "1percentile":   np.nanpercentile(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit, 1, method='closest_observation'),
-                    "99percentile":    np.nanpercentile(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit, 99, method='closest_observation'),
-                    "99pt9percentile": np.nanpercentile(ma.filled(data_as_class.intensity, np.nan) - fout.best_fit, 99.9, method='closest_observation'),
+        new_params.update(
+            {
+                "data_ranges": {
+                    "data": {
+                        "max": np.max(ma.filled(data_as_class.intensity, np.nan)),
+                        "min": np.min(ma.filled(data_as_class.intensity, np.nan)),
+                        "pt1percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan),
+                            0.1,
+                            method="closest_observation",
+                        ),
+                        "1percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan),
+                            1,
+                            method="closest_observation",
+                        ),
+                        "99percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan),
+                            99,
+                            method="closest_observation",
+                        ),
+                        "99pt9percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan),
+                            99.9,
+                            method="closest_observation",
+                        ),
+                    },
+                    "model": {
+                        "max": np.max(fout.best_fit),
+                        "min": np.min(fout.best_fit),
+                        "pt1percentile": np.nanpercentile(
+                            fout.best_fit, 0.1, method="closest_observation"
+                        ),
+                        "1percentile": np.nanpercentile(
+                            fout.best_fit, 1, method="closest_observation"
+                        ),
+                        "99percentile": np.nanpercentile(
+                            fout.best_fit, 99, method="closest_observation"
+                        ),
+                        "99pt9percentile": np.nanpercentile(
+                            fout.best_fit, 99.9, method="closest_observation"
+                        ),
+                    },
+                    "residuals": {
+                        "max": np.max(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit
+                        ),
+                        "min": np.min(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit
+                        ),
+                        "pt1percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit,
+                            0.1,
+                            method="closest_observation",
+                        ),
+                        "1percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit,
+                            1,
+                            method="closest_observation",
+                        ),
+                        "99percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit,
+                            99,
+                            method="closest_observation",
+                        ),
+                        "99pt9percentile": np.nanpercentile(
+                            ma.filled(data_as_class.intensity, np.nan) - fout.best_fit,
+                            99.9,
+                            method="closest_observation",
+                        ),
+                    },
                 }
-                }
-            })
+            }
+        )
     else:
         # remove background estimates from the defunct model
-        for i in range(len(new_params['background'])):
-            new_params['background'][i] = [None] * len(new_params['background'][i])
-            new_params['background_err'][i] = [None] * len(new_params['background'][i])
-        
+        for i in range(len(new_params["background"])):
+            new_params["background"][i] = [None] * len(new_params["background"][i])
+            new_params["background_err"][i] = [None] * len(new_params["background"][i])
+
         fit_stats = {
             "time-elapsed": t_elapsed,
             "chunks-time": chunks_time,
@@ -948,43 +1019,47 @@ def fit_sub_pattern(
         )
         new_params.update({"ModelProperties": {"max": np.nan, "min": np.nan}})
         new_params.update({"ResidualProperties": {"max": np.nan, "min": np.nan}})
-        new_params.update({'data_ranges':{
-                'data':{
-                    "max": np.max(data_as_class.intensity),
-                    "min": np.min(data_as_class.intensity),
-                    "pt1percentile": np.nanpercentile(data_as_class.intensity, 0.1),
-                    "1percentile": np.nanpercentile(data_as_class.intensity, 1),
-                    "99percentile": np.nanpercentile(data_as_class.intensity, 99),
-                    "99pt9percentile": np.nanpercentile(data_as_class.intensity, 99.9),
-                },
-                'model':{
-                    "max": np.nan,
-                    "min": np.nan,
-                    "pt1percentile": np.nan,
-                    "1percentile": np.nan,
-                    "99percentile": np.nan,
-                    "99pt9percentile": np.nan,
-                },
-                'residuals':{
-                    "max": np.nan,
-                    "min": np.nan,
-                    "pt1percentile": np.nan,
-                    "1percentile": np.nan,
-                    "99percentile": np.nan,
-                    "99pt9percentile": np.nan,
+        new_params.update(
+            {
+                "data_ranges": {
+                    "data": {
+                        "max": np.max(data_as_class.intensity),
+                        "min": np.min(data_as_class.intensity),
+                        "pt1percentile": np.nanpercentile(data_as_class.intensity, 0.1),
+                        "1percentile": np.nanpercentile(data_as_class.intensity, 1),
+                        "99percentile": np.nanpercentile(data_as_class.intensity, 99),
+                        "99pt9percentile": np.nanpercentile(
+                            data_as_class.intensity, 99.9
+                        ),
+                    },
+                    "model": {
+                        "max": np.nan,
+                        "min": np.nan,
+                        "pt1percentile": np.nan,
+                        "1percentile": np.nan,
+                        "99percentile": np.nan,
+                        "99pt9percentile": np.nan,
+                    },
+                    "residuals": {
+                        "max": np.nan,
+                        "min": np.nan,
+                        "pt1percentile": np.nan,
+                        "1percentile": np.nan,
+                        "99percentile": np.nan,
+                        "99pt9percentile": np.nan,
+                    },
                 }
-                }
-            })
-
+            }
+        )
 
     new_params.update({"FitProperties": fit_stats})
 
     # add peak names to new_params
     new_params.update({"PeakLabel": peak_string(settings_as_class.subfit_orders)})
-    #add notes if they are present.
+    # add notes if they are present.
     if "note" in settings_as_class.subfit_orders:
-            new_params.update({"note": settings_as_class.subfit_orders["note"]})
-            
+        new_params.update({"note": settings_as_class.subfit_orders["note"]})
+
     # Plot results to check
     view = 0
     if (save_fit == 1 or view == 1 or logger.is_below_level("EFFUSIVE")) and step[
@@ -1051,7 +1126,7 @@ def fit_sub_pattern(
             #     save_modelresult(out, filename)
             # else:
             #     logger.info(" ".join(map(str, [("File does not exist!")])))
-    
+
     # return [new_params, fout]
     return new_params
 

--- a/src/cpf/XRD_FitSubpattern.py
+++ b/src/cpf/XRD_FitSubpattern.py
@@ -300,7 +300,7 @@ def fit_sub_pattern(
         # N.B. null values in json file are read in as None
         any_bad_vals = has_value(previous_params, val=None)
         any_bad_vals = has_huge_errors(
-            previous_params, large_errors=large_errors, any_huge=any_bad_vals
+            previous_params, min_ratio=large_errors, is_huge=any_bad_vals
         )
         if any_bad_vals == True:
             # the previous fit has problems so discard it
@@ -753,7 +753,7 @@ def fit_sub_pattern(
                     lmm.params_to_new_params(
                         master_params, orders=settings_as_class.subfit_orders
                     ),
-                    large_errors=large_errors,
+                    min_ratio=large_errors,
                 )
                 == True
             ):

--- a/src/cpf/XRD_FitSubpattern.py
+++ b/src/cpf/XRD_FitSubpattern.py
@@ -21,7 +21,7 @@ import cpf.series_constraints as sc
 import cpf.series_functions as sf
 from cpf.fitsubpattern_chunks import fit_chunks, fit_series
 from cpf.util.io import (
-    any_errors_huge,
+    has_huge_errors,
     has_value,
     make_outfile_name,
     numpy_to_json,
@@ -299,7 +299,7 @@ def fit_sub_pattern(
         # check if the previous fit was 'good' i.e. constrains no 'null' values.
         # N.B. null values in json file are read in as None
         any_bad_vals = has_value(previous_params, val=None)
-        any_bad_vals = any_errors_huge(
+        any_bad_vals = has_huge_errors(
             previous_params, large_errors=large_errors, any_huge=any_bad_vals
         )
         if any_bad_vals == True:
@@ -749,7 +749,7 @@ def fit_sub_pattern(
             if (
                 fout.success is True
                 and previous_params != None
-                and any_errors_huge(
+                and has_huge_errors(
                     lmm.params_to_new_params(
                         master_params, orders=settings_as_class.subfit_orders
                     ),

--- a/src/cpf/XRD_FitSubpattern.py
+++ b/src/cpf/XRD_FitSubpattern.py
@@ -22,7 +22,7 @@ import cpf.series_functions as sf
 from cpf.fitsubpattern_chunks import fit_chunks, fit_series
 from cpf.util.io import (
     any_errors_huge,
-    any_terms_null,
+    has_value,
     json_numpy_serializer,
     make_outfile_name,
     peak_string,
@@ -298,7 +298,7 @@ def fit_sub_pattern(
     if previous_params:
         # check if the previous fit was 'good' i.e. constrains no 'null' values.
         # N.B. null values in json file are read in as None
-        any_bad_vals = any_terms_null(previous_params, val_to_find=None)
+        any_bad_vals = has_value(previous_params, val=None)
         any_bad_vals = any_errors_huge(
             previous_params, large_errors=large_errors, any_huge=any_bad_vals
         )
@@ -766,7 +766,7 @@ def fit_sub_pattern(
             elif (
                 fout.success is True
                 and previous_params != None
-                and any_terms_null(master_params, val_to_find=None) == True
+                and has_value(master_params, val=None) == True
             ):
                 logger.moreinfo(
                     "The fitting worked, but propagated params could have lead to rubbish fits (null values). Try again."

--- a/src/cpf/XRD_FitSubpattern.py
+++ b/src/cpf/XRD_FitSubpattern.py
@@ -23,8 +23,8 @@ from cpf.fitsubpattern_chunks import fit_chunks, fit_series
 from cpf.util.io import (
     any_errors_huge,
     has_value,
-    json_numpy_serializer,
     make_outfile_name,
+    numpy_to_json,
     peak_string,
 )
 from cpf.util.logging import get_logger
@@ -444,7 +444,7 @@ def fit_sub_pattern(
                             TempFile,
                             sort_keys=True,
                             indent=2,
-                            default=json_numpy_serializer,
+                            default=numpy_to_json,
                         )
 
                 # check if peak intensity is above threshold

--- a/src/cpf/__init__.py
+++ b/src/cpf/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from cpf.util import io
+
 __all__ = [
     "BrightSpots",
     "Cascade",
@@ -10,7 +12,7 @@ __all__ = [
     "h5_functions",
     "ImageMetaData",
     "input_types",
-    "IO_functions",
+    "io",
     "lmfit_model",
     "output_formatters",
     "peak_functions",
@@ -26,7 +28,6 @@ from cpf import (
     BrightSpots,
     Cascade,
     Cosmics,
-    IO_functions,
     XRD_FitPattern,
     XRD_FitSubpattern,
     data_preprocess,

--- a/src/cpf/fitsubpattern_chunks.py
+++ b/src/cpf/fitsubpattern_chunks.py
@@ -16,14 +16,15 @@ import cpf.histograms as hist
 import cpf.lmfit_model as lmm
 import cpf.series_constraints as sc
 import cpf.series_functions as sf
-from cpf.IO_functions import make_outfile_name, peak_string
+from cpf.util.io import make_outfile_name, peak_string
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.fitsubpattern_chunks")
 
 
-
-def get_manual_guesses(settings_as_class, data_as_class, return_converted=False, debug=False):
+def get_manual_guesses(
+    settings_as_class, data_as_class, return_converted=False, debug=False
+):
     """
     Calculate series for set of 'manual guesses' i.e. pre-defined peak centers.
 
@@ -34,7 +35,7 @@ def get_manual_guesses(settings_as_class, data_as_class, return_converted=False,
     data_as_class : cpf data class
         DESCRIPTION.
     return_converted : bool
-        Return series in d-spacing [if = True] or 
+        Return series in d-spacing [if = True] or
         collection dimension (e.g. two theta, energy) [if = False]
         The default is False
     debug : TYPE, optional
@@ -45,34 +46,39 @@ def get_manual_guesses(settings_as_class, data_as_class, return_converted=False,
     dfour : list
         List of series coefficients for each peak.
     """
-    
-    # get guesses and limits in the correct parameter 
-    peak_pos_guesses = np.array(settings_as_class.subfit_orders["PeakPositionSelection"])
+
+    # get guesses and limits in the correct parameter
+    peak_pos_guesses = np.array(
+        settings_as_class.subfit_orders["PeakPositionSelection"]
+    )
     lims = lmm.parse_bounds(
         settings_as_class.fit_bounds, data_as_class, 0, 0, param=["d-space"]
-    ) #limits alwasys in converted unit.
-    limits_range = lims['d-space']
+    )  # limits alwasys in converted unit.
+    limits_range = lims["d-space"]
     if return_converted == True:
-        #limits alwasys in converted unit no need to chamge.
-        if (np.max(peak_pos_guesses[:, 2]) > np.max(limits_range) or
-            np.min(peak_pos_guesses[:, 2]) < np.min(limits_range)):
+        # limits alwasys in converted unit no need to chamge.
+        if np.max(peak_pos_guesses[:, 2]) > np.max(limits_range) or np.min(
+            peak_pos_guesses[:, 2]
+        ) < np.min(limits_range):
             # then the peak_pos_guesses are not in d-spacing
             # therefore change
             peak_pos_guesses[:, 2] = data_as_class.conversion(
-                peak_pos_guesses[:, 2], azm=None, reverse=False)
-            
-    else: # return_converted == False:
+                peak_pos_guesses[:, 2], azm=None, reverse=False
+            )
+
+    else:  # return_converted == False:
         # limits neeed to be converted
-        limits_range = data_as_class.conversion(
-            limits_range, azm=None, reverse=True)
+        limits_range = data_as_class.conversion(limits_range, azm=None, reverse=True)
         # then check guesses
-        if (np.max(peak_pos_guesses[:, 2]) > np.max(limits_range) or
-            np.min(peak_pos_guesses[:, 2]) < np.min(limits_range)):
+        if np.max(peak_pos_guesses[:, 2]) > np.max(limits_range) or np.min(
+            peak_pos_guesses[:, 2]
+        ) < np.min(limits_range):
             # then the peak_pos_guesses are not in collected units
             # therefore change
             peak_pos_guesses[:, 2] = data_as_class.conversion(
-                peak_pos_guesses[:, 2], azm=None, reverse=True)
-     
+                peak_pos_guesses[:, 2], azm=None, reverse=True
+            )
+
     settings_as_class.validate_position_selection(
         peak_set=settings_as_class.subfit_order_position, report=False
     )
@@ -132,10 +138,10 @@ def get_chunk_background_guess(settings_as_class, data_chunk, n=1, debug=False):
 
     FIXME: background_type has been removed/depreciated. It is no longer needed. It should be replaced by background_fixed
     """
-    
+
     cnk_i = data_chunk[0]
     cnk_tth = data_chunk[1]
-    
+
     # Get indices of sorted two theta values excluding the masked values
     # tth_ord = ma.argsort(data_chunk_class.tth.compressed())
     tth_ord = np.argsort(cnk_tth)
@@ -163,12 +169,11 @@ def get_chunk_background_guess(settings_as_class, data_chunk, n=1, debug=False):
         else:  # len(orders['background']) > 1:
             # first value (offset) is mean of left-hand values
             background_guess[0][0] = np.mean(cnk_i[tth_ord[:n]])
-                # data_chunk_class.intensity.compressed()[tth_ord[:n]]
+            # data_chunk_class.intensity.compressed()[tth_ord[:n]]
             # )
             # if there are more, then calculate a gradient guess.
             background_guess[1][0] = (
-                np.mean(cnk_i[tth_ord[-n:]])
-                - np.mean(cnk_i[tth_ord[:n]])
+                np.mean(cnk_i[tth_ord[-n:]]) - np.mean(cnk_i[tth_ord[:n]])
                 # np.mean(data_chunk_class.intensity.compressed()[tth_ord[-n:]])
                 # - np.mean(data_chunk_class.intensity.compressed()[tth_ord[:n]])
             ) / (
@@ -180,6 +185,7 @@ def get_chunk_background_guess(settings_as_class, data_chunk, n=1, debug=False):
 
     return background_guess
 
+
 def get_chunk_peak_guesses_new(
     settings_as_class,
     data_chunk,
@@ -190,7 +196,7 @@ def get_chunk_peak_guesses_new(
     debug=False,
 ):
     """
-    
+
 
     Parameters
     ----------
@@ -235,11 +241,11 @@ def get_chunk_peak_guesses_new(
     :param debug:
     :return peaks, limits, p_fixed:
     """
-    
+
     cnk_i = data_chunk[0]
     cnk_tth = data_chunk[1]
     cnk_azm = data_chunk[2]
-    
+
     guess_cent = []
     guess_h = []
     guess_w = []
@@ -272,8 +278,7 @@ def get_chunk_peak_guesses_new(
             if len(background_guess) > 1:
                 h_guess = h_guess - (
                     background_guess[0][0]
-                    + background_guess[1][0]
-                    * (cnk_tth[idx] - cnk_tth.min())
+                    + background_guess[1][0] * (cnk_tth[idx] - cnk_tth.min())
                 )
             elif len(background_guess) == 1:
                 h_guess = h_guess - background_guess[0][0]
@@ -328,7 +333,7 @@ def get_chunk_peak_guesses_new(
             )
         else:
             p_guess = np.mean(settings_as_class.fit_bounds["profile"])
-        
+
         guess_cent.append(pos_guess)
         guess_h.append(h_guess)
         guess_w.append(w_guess)
@@ -389,11 +394,15 @@ def fit_chunks(
         # FIXME: Need to check that the num. of peaks for which we have parameters is the same as the
         # number of peaks guessed at.
         # dfour = get_manual_guesses(peeks, orders, bounds, twotheta, debug=None)
-        dfour = get_manual_guesses(settings_as_class, data_as_class, return_converted=False, debug=debug)
+        dfour = get_manual_guesses(
+            settings_as_class, data_as_class, return_converted=False, debug=debug
+        )
 
     # Get chunks according to detector type.
     if mode != "fit":  # cascade
-        chunks, chunk_bounds, azichunks = data_as_class.bins(settings_as_class, cascade=True)
+        chunks, chunk_bounds, azichunks = data_as_class.bins(
+            settings_as_class, cascade=True
+        )
     else:
         chunks, chunk_bounds, azichunks = data_as_class.bins(settings_as_class)
     # Final output list of azimuths with corresponding twotheta_0,h,w
@@ -431,10 +440,12 @@ def fit_chunks(
     for j in range(len(chunks)):
         # logger.info(" ".join(map(str, [('\nFitting to data chunk ' + str(j + 1) + ' of ' + str(len(chunks)) + '\n')])))
         logger.debug(f"Fitting to data chunk {j + 1} of {len(chunks)}")
-        
+
         # make data class for chunks.
         # reduce data to a subset using azi_bounds
-        chunk_data = data_as_class.duplicate(azi_bounds=chunk_bounds[j], as_masked=False)
+        chunk_data = data_as_class.duplicate(
+            azi_bounds=chunk_bounds[j], as_masked=False
+        )
         chunk_intensity = chunk_data.intensity
         chunk_tth = chunk_data.tth
         chunk_azm = chunk_data.azm
@@ -448,9 +459,7 @@ def fit_chunks(
 
         elif mode == "range":
             # get maximum from each chunk
-            out_vals["h"][0].append(
-                np.max(chunk_intensity) - np.min(chunk_intensity)
-            )
+            out_vals["h"][0].append(np.max(chunk_intensity) - np.min(chunk_intensity))
             out_vals["chunks"].append(azichunks[j])
             new_azi_chunks.append(azichunks[j])
 
@@ -467,15 +476,13 @@ def fit_chunks(
             if len(chunk_intensity) >= min_dat:
                 # integrate (smooth) the chunks
                 if histogram_type != None:
-                    chunk_tth, chunk_intensity, chunk_azm = (
-                        hist.histogram1d(
-                            chunk_tth,
-                            chunk_intensity,
-                            azi=chunk_azm,
-                            histogram_type=histogram_type,
-                            bin_n=histogram_bins,
-                            debug=debug,
-                        )
+                    chunk_tth, chunk_intensity, chunk_azm = hist.histogram1d(
+                        chunk_tth,
+                        chunk_intensity,
+                        azi=chunk_azm,
+                        histogram_type=histogram_type,
+                        bin_n=histogram_bins,
+                        debug=debug,
                     )
 
                 # append azimuth to output
@@ -497,27 +504,37 @@ def fit_chunks(
                 )
                 # cent_guess is in collected units. needs converting.
                 lims = lmm.parse_bounds(
-                    settings_as_class.fit_bounds, data_as_class, 0, len(cent_guess), param=["d-space"]
-                ) #limits alwasys in converted unit.
-                limits_range = lims['d-space']
-                
-                if (np.max(cent_guess) > np.max(limits_range) or
-                    np.min(cent_guess) < np.min(limits_range)):
+                    settings_as_class.fit_bounds,
+                    data_as_class,
+                    0,
+                    len(cent_guess),
+                    param=["d-space"],
+                )  # limits alwasys in converted unit.
+                limits_range = lims["d-space"]
+
+                if np.max(cent_guess) > np.max(limits_range) or np.min(
+                    cent_guess
+                ) < np.min(limits_range):
                     # then the peak_pos_guesses are not in d-spacing
                     # therefore change
-                    cent_guess = list(np.atleast_1d(data_as_class.conversion(
-                        cent_guess, azm=None, reverse=False)))
+                    cent_guess = list(
+                        np.atleast_1d(
+                            data_as_class.conversion(
+                                cent_guess, azm=None, reverse=False
+                            )
+                        )
+                    )
                 # convert to dictionary
                 peaks = []
-                for a,b,c,d in zip(cent_guess, h_guess, w_guess, p_guess):
+                for a, b, c, d in zip(cent_guess, h_guess, w_guess, p_guess):
                     peaks.append(
-                                {
-                                    "d-space": [a],
-                                    "height": [b],
-                                    "width": [c],
-                                    "profile": [d],
-                                }
-                            )
+                        {
+                            "d-space": [a],
+                            "height": [b],
+                            "width": [c],
+                            "profile": [d],
+                        }
+                    )
 
                 comp_list = ["h", "d", "w", "p"]
                 comp_names = ["height", "d-space", "width", "profile"]
@@ -780,7 +797,7 @@ def fit_series(
                 fixed = 0
                 data_vals = data[0][comp][j]
                 data_val_errors = data[0][comp + "_err"][j]
-                data_val_errors = clean_errs(data_val_errors, outliers=2)     
+                data_val_errors = clean_errs(data_val_errors, outliers=2)
 
             #     # FIX ME: this was not checked properly.the values it feeds are not necessarily correct
             #     # and the fixed parameters might be fit for.
@@ -861,16 +878,13 @@ def fit_series(
                     param=temp[0],
                     coeff_type=temp_tp,
                 )
-                ax[i].plot(
-                    az_plt,
-                    gmod_plot
-                )
+                ax[i].plot(az_plt, gmod_plot)
                 ax[i].scatter(data[1], data[0][comp][j], s=10)
-                
+
             # set y limits ignoring the error bars
             y_lms = ax[i].get_ylim()
             ax[i].set_ylim(y_lms)
-            
+
             for j in range(len(orders["peak"])):
                 # add error bars to data points, over the top of the points
                 ax[i].errorbar(
@@ -880,7 +894,7 @@ def fit_series(
                     fmt="none",
                     elinewidth=0.5,
                 )
-            
+
             # set x-ticks by data type.
             # if notthing in the data class then continue
             try:

--- a/src/cpf/h5_functions.py
+++ b/src/cpf/h5_functions.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import cpf.XRD_FitPattern as fp
 from cpf.util.io import (
-    StartStopFilesToList,
+    get_file_keys,
     licit_filename,
     make_outfile_name,
     title_file_names,
@@ -981,7 +981,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 if itera["to"] == -1:
                     itera["to"] = float(vals[-1][0])
 
-                keep, _ = StartStopFilesToList(paramDict=itera)
+                keep, _ = get_file_keys(param_dict=itera)
             present = np.atleast_1d(
                 np.array(
                     [
@@ -1003,7 +1003,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 if itera["to"] == -1:
                     itera["to"] = int(len(vals)) - 1
 
-                keep, _ = StartStopFilesToList(paramDict=itera)
+                keep, _ = get_file_keys(param_dict=itera)
             keylist = [keylist[x] for x in keep]
             vals = [vals[x] for x in keep]
 
@@ -1040,7 +1040,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 else:
                     if itera["to"] == -1:
                         itera["to"] = number_data - 1
-                    index_values, _ = StartStopFilesToList(paramDict=itera)
+                    index_values, _ = get_file_keys(param_dict=itera)
                 # get the labels -- only need labels from layers above because summing the data.
                 lbls = licit_filename(labels[i], replacement="+", exclude_dir=False)
                 # lbls = get_labels(df, itera["label"],  number_data, j, vals[i], sep1=sep1, sep2=sep2, key=labels[i])
@@ -1054,7 +1054,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 else:
                     if itera["to"] == -1:
                         itera["to"] = number_data - 1
-                    index_values, _ = StartStopFilesToList(paramDict=itera)
+                    index_values, _ = get_file_keys(param_dict=itera)
                 # get the labels -- only need labels from layers above because returning data array.
                 lbls = licit_filename(labels[i], replacement="+", exclude_dir=False)
                 # lbls = get_labels(df, itera["label"],  number_data, j, vals[i], sep1=sep1, sep2=sep2, key=labels[i])

--- a/src/cpf/h5_functions.py
+++ b/src/cpf/h5_functions.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import cpf.XRD_FitPattern as fp
 from cpf.util.io import (
-    get_file_keys,
+    get_file_indices,
     licit_filename,
     make_outfile_name,
     title_file_names,
@@ -981,7 +981,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 if itera["to"] == -1:
                     itera["to"] = float(vals[-1][0])
 
-                keep, _ = get_file_keys(param_dict=itera)
+                keep, _ = get_file_indices(param_dict=itera)
             present = np.atleast_1d(
                 np.array(
                     [
@@ -1003,7 +1003,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 if itera["to"] == -1:
                     itera["to"] = int(len(vals)) - 1
 
-                keep, _ = get_file_keys(param_dict=itera)
+                keep, _ = get_file_indices(param_dict=itera)
             keylist = [keylist[x] for x in keep]
             vals = [vals[x] for x in keep]
 
@@ -1040,7 +1040,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 else:
                     if itera["to"] == -1:
                         itera["to"] = number_data - 1
-                    index_values, _ = get_file_keys(param_dict=itera)
+                    index_values, _ = get_file_indices(param_dict=itera)
                 # get the labels -- only need labels from layers above because summing the data.
                 lbls = licit_filename(labels[i], replacement="+", exclude_dir=False)
                 # lbls = get_labels(df, itera["label"],  number_data, j, vals[i], sep1=sep1, sep2=sep2, key=labels[i])
@@ -1054,7 +1054,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 else:
                     if itera["to"] == -1:
                         itera["to"] = number_data - 1
-                    index_values, _ = get_file_keys(param_dict=itera)
+                    index_values, _ = get_file_indices(param_dict=itera)
                 # get the labels -- only need labels from layers above because returning data array.
                 lbls = licit_filename(labels[i], replacement="+", exclude_dir=False)
                 # lbls = get_labels(df, itera["label"],  number_data, j, vals[i], sep1=sep1, sep2=sep2, key=labels[i])

--- a/src/cpf/h5_functions.py
+++ b/src/cpf/h5_functions.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import cpf.XRD_FitPattern as fp
-from cpf.IO_functions import (
+from cpf.util.io import (
     StartStopFilesToList,
     licit_filename,
     make_outfile_name,
@@ -560,10 +560,10 @@ def DefaultProcessDictionary(types=False):
         return {
             "do": {"type": str, "values": ["sum", "iterate", "combine"]},
             "from": {"type": (int, float, np.ndarray)},
-            "to":   {"type": (int, float, np.ndarray)},
+            "to": {"type": (int, float, np.ndarray)},
             "step": {"type": (int)},
-            "list": {"type": list}, # this is possible but not in the default set.
-            "dim":  {"type": (int)},
+            "list": {"type": list},  # this is possible but not in the default set.
+            "dim": {"type": (int)},
             "using": {"type": str, "values": ["value", "position"]},
             "label": {"type": (list, str)},
         }
@@ -627,7 +627,10 @@ def update_key_structure(fit_parameters):
         if fit_parameters["h5_key_list"][i][0] != "/":
             h5datakey += "/"
         h5datakey += fit_parameters["h5_key_list"][i]
-        if i < len(fit_parameters["h5_key_list"]) and i != len(fit_parameters["h5_key_list"]) - 1:
+        if (
+            i < len(fit_parameters["h5_key_list"])
+            and i != len(fit_parameters["h5_key_list"]) - 1
+        ):
             h5datakey += "*"
 
     # convert everything else into a dictionary.
@@ -662,9 +665,7 @@ def update_key_structure(fit_parameters):
     return h5datakey, h5iterations
 
 
-def image_key_validate_new(
-    fit_settings=None, h5_iterate=None, end_if_errors=False
-):
+def image_key_validate_new(fit_settings=None, h5_iterate=None, end_if_errors=False):
     """
     Validates the lengths and structure of h5_iterate, which is the list/dictionary
     of h5 file key values and labels.
@@ -882,13 +883,13 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
     # this is necessary incase we are looping over all valid entries without
     # directly knowing the key names
     keylist = []
-    
+
     if loops:
         for i in range(len(loops)):
             # FIXME this loop should be an iterative loop. so that it can iterate
             # over as many keys as required.
-    
-            # list all the keys that may match the wild card -- then cut list to 
+
+            # list all the keys that may match the wild card -- then cut list to
             # matching values
             # key before wildcard.
             h5key_data_sub = h5key_data[: max(j for j in dividers if j < loops[i]) + 1]
@@ -896,7 +897,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
             lst_all = h5_tree(df[h5key_data_sub], list_of_keys=[], recurse=False)
             # FIXME: the h5tree function call needs list_of_keys=[] otherwise during
             # testing when the function is run it appends to the previous list of keys.
-    
+
             ## get list of values that matches the wildcard.
             # find part of key before separation after wildcard.
             # cannot assume that the wildcard is the last part of the keyname.
@@ -909,14 +910,14 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
             lst = list(filter(re.compile(h5key_data_sub).match, lst_all))
             ## get keys that match that have subkeys matching h5key_data
             # cannot assume that all the keys have the same subdata.
-    
+
             # capture numerical values in keys.
             vals = []
             for i in range(len(lst)):
                 vals_tmp = re.search(h5key_data_sub, lst[i])
                 # get values from regexpression
                 vals.append(list(vals_tmp.groups()))
-    
+
             # check if the key exists.
             for j in range(len(vals)):
                 # replace * with number using regular expresion
@@ -927,28 +928,28 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                     keylist.append(h5key_data_sub)
                 except:
                     pass
-    
+
         if 0:  # for debugging
             # get all keys in h5 file [CAUTION could be slow if files are large]
             key_list_all = h5_tree(df)
-    
+
             # setup h5key_data to be used.
             # replace * with number using regular expresion
             h5key_data = re.sub(r"\*", regexp_num, h5key_data)
             # make sure ends with a $
             if h5key_data[-1] != "$":
                 h5key_data = h5key_data + regexp_end
-    
+
             # get list of matching keys
             keylist = list(filter(re.compile(h5key_data).match, key_list_all))
-    
+
         # capture numerical values in keys.
         vals = []
         for i in range(len(keylist)):
             vals_tmp = re.search(re.sub(r"\*", regexp_alphanum, h5key_data), keylist[i])
             # get values from regexpression
             vals.append(list(vals_tmp.groups()))
-    
+
         # sort values and keys into order.
         try:
             vals_num = np.array(vals).astype(float)
@@ -959,10 +960,10 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
         except:
             pass
     else:
-         #there is no wild card in the h5key_data
-         keylist = [h5key_data]
-         vals = [['1']]
-    
+        # there is no wild card in the h5key_data
+        keylist = [h5key_data]
+        vals = [["1"]]
+
     # cut list to size.
     present = []
     for i in range(len(loops)):
@@ -979,8 +980,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                     itera["from"] = float(vals[0][0])
                 if itera["to"] == -1:
                     itera["to"] = float(vals[-1][0])
-    
-    
+
                 keep, _ = StartStopFilesToList(paramDict=itera)
             present = np.atleast_1d(
                 np.array(
@@ -1021,10 +1021,10 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
 
         labels.append("")
         # for j in range(len(h5_iterate)):
-                       
-            # look at the last of the iteration keys.
-            # deepcopy so can check for "to": -1 every time round.
-            # itera = deepcopy(h5_iterate[j])
+
+        # look at the last of the iteration keys.
+        # deepcopy so can check for "to": -1 every time round.
+        # itera = deepcopy(h5_iterate[j])
         itera = deepcopy(h5_iterate[-1])
 
         # make sure the key exists
@@ -1047,7 +1047,7 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                 out.append([keylist[i], index_values, lbls])
 
             elif itera["do"] == "combine":
-                # return all the frames. 
+                # return all the frames.
                 # Used for building compound detectors (e.g. ESRF lvp detector)
                 if "list" in itera:
                     index_values = itera["list"]
@@ -1087,11 +1087,11 @@ def get_image_keys_new(datafile, h5key_data, h5_iterate, sep1="_", sep2="="):
                         lbls += f"{sep1}{additional_label}"
 
                     # if itera["using"] == "value" and :
-                    out.append([keylist[i], index_values, lbls])    
+                    out.append([keylist[i], index_values, lbls])
             else:
                 err_str = f"The h5 process '{itera['do']}' is not recognised."
                 raise ValueError(err_str)
-    
+
     df.close()
     return out
 
@@ -1195,25 +1195,26 @@ def get_labels(
 
 # %%
 
+
 def get_images(
     image_list=None,
     settings_file=None,
     settings_class=None,
-    do = 'iterate',
-    dimension = 0,
+    do="iterate",
+    dimension=0,
     image_num=None,
     debug=False,
 ):
     """
     Export single images from h5 files for use with Dioptas.
 
-    Expected input is of the format: 
-     [   
+    Expected input is of the format:
+     [
       [ file_name, ["data_Key", 'position in key', label]],
        ...
        [ file_name, ["data_Key", 'position in key', label]]
     ]
-     
+
     the inner "["data_Key", 'position in key', label]" is returned by get_image_keys_new()
 
     Parameters
@@ -1248,42 +1249,46 @@ def get_images(
             "There are no settings or image_list. The fitting cannot proceed until a recognised "
             "settings file or class is present."
         )
-    
+
     # how to return the data.
     if settings_class and "h5_iterate" in settings_class.__dict__:
-        do = settings_class.h5_iterate[-1].get('do', do)
-        dim = settings_class.h5_iterate[-1].get('dim', dimension)
-    
+        do = settings_class.h5_iterate[-1].get("do", do)
+        dim = settings_class.h5_iterate[-1].get("dim", dimension)
+
     datafile = h5py.File(image_list[0], "r")
     datakey = image_list[1]
     data_position_in_key = image_list[2]
-    if datafile[datakey].size == 1: 
+    if datafile[datakey].size == 1:
         data = np.array(datafile[datakey].squeeze()[()])
     else:
-        # if ((not setttings_class) or 
-        #     data_position_in_key.size == 1 or 
-        #     len(data_position_in_key) == 1 or 
+        # if ((not setttings_class) or
+        #     data_position_in_key.size == 1 or
+        #     len(data_position_in_key) == 1 or
         #     do == "iterate"):
         if do == "iterate":
             # then take the slice/value given
             data = np.array(datafile[datakey]).squeeze()[data_position_in_key]
-        elif do == "combine": # multi slice data that might something doing to it
+        elif do == "combine":  # multi slice data that might something doing to it
             data = np.array(datafile[datakey]).squeeze()[data_position_in_key]
-        elif do == "sum": # multi slice data that needs collapsing
-            data = np.array(datafile[datakey]).squeeze()[data_position_in_key].sum(axis=dim)
+        elif do == "sum":  # multi slice data that needs collapsing
+            data = (
+                np.array(datafile[datakey])
+                .squeeze()[data_position_in_key]
+                .sum(axis=dim)
+            )
             # stop
             # if not settings_class:
-            #     # just return everything 
+            #     # just return everything
             #     data = np.array(datafile[datakey]).squeeze()[data_position_in_key]
             # else:
-                
-            #     # assume that we are summing over the first dimension. 
+
+            #     # assume that we are summing over the first dimension.
             #     dim = 0
             # else:
             #     # get dim from settings
             #     dim = settings_class.h5_iterate[-1]["dim"]
             # data = np.array(datafile[datakey]).squeeze()[data_position_in_key]#.sum(axis=dim)
-    
+
     return np.array(data)
 
 

--- a/src/cpf/input_types/DioptasFunctions.py
+++ b/src/cpf/input_types/DioptasFunctions.py
@@ -3,38 +3,37 @@
 
 __all__ = ["DioptasDetector"]
 
-import sys
-from copy import copy, deepcopy
-from importlib.metadata import version
 import os
 import re
-from pathlib import Path
+import sys
 import types
+from copy import copy, deepcopy
+from importlib.metadata import version
+from pathlib import Path
+
 import fabio
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 import pyFAI
-from pyFAI.detectors.orientation import Orientation
 from packaging.version import Version
+from pyFAI.detectors.orientation import Orientation
 
 # Logic to support multiple PyFAI versions
 if Version(version("pyFAI")).major >= 2025:
     from pyFAI.integrator.azimuthal import AzimuthalIntegrator
 else:
     from pyFAI.azimuthalIntegrator import AzimuthalIntegrator
-from pyFAI.io import ponifile
+from pyFAI.io import DefaultAiWriter, ponifile
 
+import cpf  # need to import whole package to avoind trying to import part of incompletely iniated method (cpf.settings.issettings for _get_metadata)
 import cpf.h5_functions as h5_functions
-import cpf # need to import whole package to avoind trying to import part of incompletely iniated method (cpf.settings.issettings for _get_metadata)
-from cpf import IO_functions
 from cpf.input_types._AngleDispersive_common import _AngleDispersive_common
-from cpf.input_types._metadata_common import _metadata_common
 from cpf.input_types._Masks import _masks
+from cpf.input_types._metadata_common import _metadata_common
 from cpf.input_types._Plot_AngleDispersive import _Plot_AngleDispersive
+from cpf.util import io
 from cpf.util.logging import get_logger
-
-from pyFAI.io import DefaultAiWriter
 
 logger = get_logger("cpf.input_types.DioptasFunctions")
 
@@ -82,23 +81,28 @@ class DioptasDetector:
         self.reduce_by = None
 
         self.metadata = None
-        self._default_metadata_labels_tiff  = {"time": "FILE_MODIFIED", # file creation time.
-                                  }
+        self._default_metadata_labels_tiff = {
+            "time": "FILE_MODIFIED",  # file creation time.
+        }
         self._default_metadata_labels_hdf5 = {}
         # self._default_metadata_labels = {"time": "FILE_MODIFIED", # file creation time.
         #                           }
-        
-        self._default_h5_datakey = '/*.1/measurement/p3/'
-        self._default_h5_iterate = [{"from": 0, "to": 0, "step": 1, "label":["pos"], "do":"iterate"},
-                           {"do":"combine", 
-                 "from": 0, 
-                 "to": -1, 
-                 "step": 1, 
-                 "using":"position",
-                 "label": ['pos'],
-                 # "pos": '/*.1/measurement/azim/',
-                 "dim": 0}]
-        
+
+        self._default_h5_datakey = "/*.1/measurement/p3/"
+        self._default_h5_iterate = [
+            {"from": 0, "to": 0, "step": 1, "label": ["pos"], "do": "iterate"},
+            {
+                "do": "combine",
+                "from": 0,
+                "to": -1,
+                "step": 1,
+                "using": "position",
+                "label": ["pos"],
+                # "pos": '/*.1/measurement/azim/',
+                "dim": 0,
+            },
+        ]
+
         self.calibration = None
         self.conversion_constant = None
         self.detector = None
@@ -109,7 +113,13 @@ class DioptasDetector:
             if self.calibration:
                 self.detector = self.get_detector(settings=settings_class)
 
-    def duplicate(self, range_bounds=[-np.inf, np.inf], azi_bounds=[-np.inf, np.inf], with_detector=True, as_masked=True):
+    def duplicate(
+        self,
+        range_bounds=[-np.inf, np.inf],
+        azi_bounds=[-np.inf, np.inf],
+        with_detector=True,
+        as_masked=True,
+    ):
         """
         Makes an independent copy of a DioptasDetector Instance.
 
@@ -136,27 +146,33 @@ class DioptasDetector:
             Copy of DioptasDetector with independedent data values
 
         """
-        #FIXME: should merge the data reduction funtions here with set_limits. or call set_limits.
-        #FIXME: should be able to copy the class and reduce data at the same time. rather than copying and then reducing
-        # this is not memory efficient. 
-        
-        
+        # FIXME: should merge the data reduction funtions here with set_limits. or call set_limits.
+        # FIXME: should be able to copy the class and reduce data at the same time. rather than copying and then reducing
+        # this is not memory efficient.
+
         # list variables that are not just straight copied
-        copy_separately = ["intensity", "tth", "azm",
-                           "x", "y", "z",
-                           "dspace",
-                           "tth_start", "tth_end"]
+        copy_separately = [
+            "intensity",
+            "tth",
+            "azm",
+            "x",
+            "y",
+            "z",
+            "dspace",
+            "tth_start",
+            "tth_end",
+        ]
         dont_copy = ["detector", "calibration"]
-        
-        #validate the ranges
+
+        # validate the ranges
         range_bounds, azi_bounds = self.check_bounds(range_bounds, azi_bounds)
-        
+
         if with_detector:
             new = copy(self)
             # do not return here because likely need to cut the data down
         elif 0:
-            # copy and then delete the detector and calibration, 
-            # so that all other non-default values are propagated.    
+            # copy and then delete the detector and calibration,
+            # so that all other non-default values are propagated.
             new = deepcopy(self)
             for i in dont_copy:
                 setattr(new, i, None)
@@ -164,36 +180,35 @@ class DioptasDetector:
             # new.calibration = None
         else:
             # make new detector instance.
-            # assume the methods are not altered and 
+            # assume the methods are not altered and
             # add the common variables to ensure consistent behaviour
             new = DioptasDetector()
-            
+
             # copy all the settings ignoring any methods
             for i in dir(new):
-                if (type(getattr(new, i)) == types.MethodType or 
-                    i[:2] == "__"):
+                if type(getattr(new, i)) == types.MethodType or i[:2] == "__":
                     # skip method copying or default object
                     continue
                 elif i in dont_copy:
                     # set dont copy parameters to 0
                     setattr(new, i, None)
                 elif i not in copy_separately:
-                    # copy common parameters 
+                    # copy common parameters
                     setattr(new, i, getattr(self, i))
                 elif i in copy_separately:
                     # skip adding the variables in 'copy_separately'
                     # these are added below.
-                    # *may* be more memory efficient than copying huge arrays and 
+                    # *may* be more memory efficient than copying huge arrays and
                     # then making them smaller.
                     continue
                 else:
                     raise ValueError("Should not be possible to get here")
-            
+
         # set new range.
         new.tth_start = range_bounds[0]
         new.tth_end = range_bounds[1]
-        
-        # restrict the data. 
+
+        # restrict the data.
         local_mask = np.where(
             (self.tth >= new.tth_start)
             & (self.tth <= new.tth_end)
@@ -205,7 +220,7 @@ class DioptasDetector:
         new.azm = self.azm[local_mask]
         if "dspace" in dir(self):
             new.dspace = self.dspace[local_mask]
-       
+
         if "x" in dir(new):
             if self.x is not None:
                 new.x = self.x[local_mask]
@@ -258,7 +273,7 @@ class DioptasDetector:
             parms_file = settings.calibration_parameters
         else:
             parms_file = file_name
-            
+
         if 0:
             """
             FIXME: If there is no specific detector type set in the calibration
@@ -266,19 +281,19 @@ class DioptasDetector:
               "No sensor configuration provided; using default behaviour."
             This is just unfortunate but does not cause a problem.
             the way round this is to read the poni file as a dictionary and then
-            pipe it back to the ponifile object. 
-            
+            pipe it back to the ponifile object.
+
             if not warnings are raised everytime the object is copied/duplicated
-            
-            The code below also raises warnings on other detectors that are specified. 
-            
+
+            The code below also raises warnings on other detectors that are specified.
+
             Instead change how the duplication of the detector works.
             """
             import json
-            
-            # read a poni file into 
+
+            # read a poni file into
             pf_data = {}
-            with open(parms_file, 'r') as f:
+            with open(parms_file, "r") as f:
                 for line in f:
                     line = line.strip()
                     if not line or line.startswith("#"):
@@ -294,44 +309,49 @@ class DioptasDetector:
                     pf_data[key] = parsed_value
             if pf_data["detector"].lower() == "detector":
                 # it is a generic detector without sensor specification.
-                # add this to supress warnings. 
-                pf_data["detector_config"].update({'sensor': {'material': 'CdTe', 'thickness': 0.001}})
-                pf_data["detector_config"].update({'sensor': pyFAI.detectors.sensors.SensorConfig.parse("CdTe, 1mm")})
-            
+                # add this to supress warnings.
+                pf_data["detector_config"].update(
+                    {"sensor": {"material": "CdTe", "thickness": 0.001}}
+                )
+                pf_data["detector_config"].update(
+                    {"sensor": pyFAI.detectors.sensors.SensorConfig.parse("CdTe, 1mm")}
+                )
+
             pf = ponifile.PoniFile()
             # pf.read_from_file(parms_file)
             pf.read_from_dict(pf_data)
         else:
             pf = ponifile.PoniFile()
             pf.read_from_file(parms_file)
-            
-        if pf.API_VERSION <2:
+
+        if pf.API_VERSION < 2:
             # then there is no orientation information in the poni file
             error_str = "Support for poni v1 files has been depreciated. To proceed update your poni file to version>=2"
             logger.error(error_str)
             import sys
+
             sys.exit(error_str)
-            
+
             # then there is no orientation information in the poni file
             # assume an orientation, add and update pf
             config = pf.detector.get_config()
             config["orientation"] = 2
             pf.detector.set_config(config)
-            #set the orientation which means AP_VERIOSN >= 2
+            # set the orientation which means AP_VERIOSN >= 2
             pf.API_VERSION = 2.1
         if (
-            not isinstance(settings.image_list[0], list) and 
-            pf.as_dict().get("poni_version", 1) >= 2 and 
-            "orientation" in pf.detector.get_config()
+            not isinstance(settings.image_list[0], list)
+            and pf.as_dict().get("poni_version", 1) >= 2
+            and "orientation" in pf.detector.get_config()
         ):
-            # FIXME: this doesnt make sense to me.  
-            # can't flip if using hdf5 type images (if image_list[0] is list) because 
-            # the images are then upsude down relative to dioptas. 
-            
+            # FIXME: this doesnt make sense to me.
+            # can't flip if using hdf5 type images (if image_list[0] is list) because
+            # the images are then upsude down relative to dioptas.
+
             # Check orientation and patch it since pyFAI and Dioptas use different conventions:
             # - Dioptas convention: origin at the top right when looking from the sample
-            # - Default pyFAI convention: origin at the bottom right when looking from the sample   
-            
+            # - Default pyFAI convention: origin at the bottom right when looking from the sample
+
             """Flips the detector up-down orientation in a poni configuration dictionary. Changes the dictionary object
             in place.
             """
@@ -388,7 +408,8 @@ class DioptasDetector:
         """
         if self.calibration == None:
             self.get_calibration(
-                settings=settings, file_name=calibration_file,
+                settings=settings,
+                file_name=calibration_file,
             )
 
         if self.calibration:
@@ -402,14 +423,18 @@ class DioptasDetector:
                 rot2=self.calibration.rot2,
                 rot3=self.calibration.rot3,
                 wavelength=self.calibration.wavelength,
-                orientation=self.calibration.detector.get_config()["orientation"]
+                orientation=self.calibration.detector.get_config()["orientation"],
             )
 
-            
     # @staticmethod
     def import_image(
-        self, image_name=None, settings=None, mask=None, dtype=None, 
-        reduce_by = None, debug=False
+        self,
+        image_name=None,
+        settings=None,
+        mask=None,
+        dtype=None,
+        reduce_by=None,
+        debug=False,
     ):
         """
         Import the data image into the intensity array.
@@ -457,16 +482,18 @@ class DioptasDetector:
         if isinstance(image_name, list):
             # then it is a h5 type file (including *.nxs)
             im = h5_functions.get_images(image_name, settings_class=settings)
-            
-            #add metadata to instance.
-            #done here so only need to open file once.
+
+            # add metadata to instance.
+            # done here so only need to open file once.
             self._set_metadata(None, settings=settings)
 
         else:
             # presume it is an image file.
             try:
                 im_all = fabio.open(image_name)
-                logger.moreinfo(f"This file contains {im_all.nframes} frame(s) with a combined shape of {im_all.shape}")
+                logger.moreinfo(
+                    f"This file contains {im_all.nframes} frame(s) with a combined shape of {im_all.shape}"
+                )
             except:
                 err_str = "".join(
                     [
@@ -476,10 +503,10 @@ class DioptasDetector:
                     ]
                 )
                 raise ValueError(err_str)
-                
+
             if im_all.nframes == 1:
                 # squeeze to make sure 1st dimension is not 1.
-                im = im_all.data.squeeze()  
+                im = im_all.data.squeeze()
             else:
                 err_str = "".join(
                     [
@@ -488,11 +515,11 @@ class DioptasDetector:
                     ]
                 )
                 raise NotImplementedError(err_str)
-                
-            #add metadata to instance.
-            #done here so only need to open file once.
+
+            # add metadata to instance.
+            # done here so only need to open file once.
             self._set_metadata(im_all, settings=settings)
-        
+
         # Convert the input data from integer to float because the lmfit model values
         # inherits integer properties from the data.
         #
@@ -507,10 +534,10 @@ class DioptasDetector:
 
         # Dioptas flips the images to match the orientations in Fit2D
         # Therefore implemented here to be consistent with Dioptas.
-        # flip both the image and the calibration separately to allow subsequent 
+        # flip both the image and the calibration separately to allow subsequent
         # loading of more images.
         im = np.array(im)[::-1]
-        
+
         # reduce the size of the data (if called for)
         if reduce_by is not None or self.reduce_by is not None:
             if reduce_by is False:
@@ -526,23 +553,25 @@ class DioptasDetector:
         if logger.is_below_level(level="DEBUG"):
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            asdf = ax.imshow(np.log10(im+1E4))
+            asdf = ax.imshow(np.log10(im + 1e4))
             # print(np.log10(im))
-            plt.title(IO_functions.title_file_names(image_name=image_name))
+            plt.title(io.title_file_names(image_name=image_name))
             plt.colorbar(asdf)
             plt.show()
             plt.close()
 
-        
         # apply mask to the intensity array
         if mask == None and ma.is_masked(self.intensity) == False:
             self.intensity = ma.array(im)
             return ma.array(im)
-        elif ma.is_masked(self.intensity) == True and self.intensity.mask.shape == im.shape:
+        elif (
+            ma.is_masked(self.intensity) == True
+            and self.intensity.mask.shape == im.shape
+        ):
             # apply mask from previous intensities and all are same size
             self.intensity = ma.array(im, mask=self.intensity.mask)
             return ma.array(im)
-        else:#if mask is not None:
+        else:  # if mask is not None:
             # apply given mask
             self.intensity = ma.array(im, mask=self.get_mask(mask, im))
             return ma.array(im, mask=mask)
@@ -550,7 +579,6 @@ class DioptasDetector:
         #     # apply new mask
         #     self.intensity = ma.array(im, mask=self.fill_mask(mask, im))
         #     return ma.array(im, mask=mask)
-
 
     def fill_data(
         self, diff_file=None, settings=None, mask=None, make_zyx=False, debug=False
@@ -606,25 +634,29 @@ class DioptasDetector:
 
         if settings.reduce_by is not None:
             self.reduce_by = settings.reduce_by
-            
+
         if settings.metadata_labels is not None:
             self.metadata_labels = settings.metadata_labels
-        if (isinstance(diff_file, list) or 
-              os.path.splitext(os.path.basename(diff_file))[1] == ".h5" or 
-              os.path.splitext(os.path.basename(diff_file))[1] == ".nxs"):
+        if (
+            isinstance(diff_file, list)
+            or os.path.splitext(os.path.basename(diff_file))[1] == ".h5"
+            or os.path.splitext(os.path.basename(diff_file))[1] == ".nxs"
+        ):
             self._default_metadata_labels = self._default_metadata_labels_hdf5
             self.metadata_labels = self._default_metadata_labels_hdf5
         else:
             self._default_metadata_labels = self._default_metadata_labels_tiff
             self.metadata_labels = self._default_metadata_labels_tiff
-            
+
         if self.detector == None:
             self.get_detector(settings=settings)
 
         # get the intensities (without mask) and without reduction.
         # No reduction because if reduced then the calibration is nonsence.
-        self.intensity = self.import_image(diff_file, settings=settings, reduce_by=False)
-        
+        self.intensity = self.import_image(
+            diff_file, settings=settings, reduce_by=False
+        )
+
         # FIXME: (June 2024) because of how self.detector is instanciated the
         # shape might not be correct (or recognised). Hence the check here and
         # inclusion of the shape in the array getting.
@@ -635,12 +667,8 @@ class DioptasDetector:
                 "The pixel size of the data and the detector are not the same"
             )
 
-        self.tth = ma.array(
-            self.detector.center_array(unit='2th_deg')
-        )
-        self.azm = ma.array(
-            self.detector.center_array(unit='chi_deg')
-        )
+        self.tth = ma.array(self.detector.center_array(unit="2th_deg"))
+        self.azm = ma.array(self.detector.center_array(unit="chi_deg"))
         # self.dspace = self._get_d_space()
         if make_zyx:
             zyx = self.detector.calc_pos_zyx()
@@ -656,10 +684,10 @@ class DioptasDetector:
             self.intensity = self._reduce_array(self.intensity)
             self.tth = self._reduce_array(self.tth)
             self.azm = self._reduce_array(self.azm, polar=True)
-            
+
             if "original_mask" in dir(self):
-                self.original_mask= self._reduce_array(self.original_mask)
-                
+                self.original_mask = self._reduce_array(self.original_mask)
+
             if make_zyx:
                 self.z = self._reduce_array(self.z)
                 self.y = self._reduce_array(self.y)
@@ -674,34 +702,33 @@ class DioptasDetector:
         self.tth_start = np.min(self.tth.flatten())
         self.tth_end = np.max(self.tth.flatten())
 
-
     def _set_metadata(self, image_obj, settings=None):
         """
         Adds all possible metadata values as dictionary within the in the data_class.
-        
-        The values that are in settings.metadata (a list) are extracted subsequently using data_class.get_metadata 
-               
-        If the cpf settings class is provided and has the method 'metadata_read_func'
-        then this method is used to override the internal default methods and is 
-        used to create 'metadata_dictionary' which is parsed.
-        In this case the settings class attribute 'metadata_labels' is still needed 
-        to get required parts of the metadata. 
 
-        For Dioptas functions the default is a fabio.open(file).header dictionary 
-        
+        The values that are in settings.metadata (a list) are extracted subsequently using data_class.get_metadata
+
+        If the cpf settings class is provided and has the method 'metadata_read_func'
+        then this method is used to override the internal default methods and is
+        used to create 'metadata_dictionary' which is parsed.
+        In this case the settings class attribute 'metadata_labels' is still needed
+        to get required parts of the metadata.
+
+        For Dioptas functions the default is a fabio.open(file).header dictionary
+
         Parameters
         ----------
         image_obj : fabio object
             image object to be parsed.
         settings : cpf settings class, optional
-            If the settings class has method 'metadata_read' this overrides the 
-            internal methods and is used to get the metadata. 
+            If the settings class has method 'metadata_read' this overrides the
+            internal methods and is used to get the metadata.
             The default is None.
 
         Returns
         -------
         metadata_dictionary
-            dictionary of image metadata. 
+            dictionary of image metadata.
         """
         # Defined as function to allow get_metadata to call universal image method
         metadata_dictionary = {}
@@ -710,38 +737,46 @@ class DioptasDetector:
             # expected behaviour in some circumstances.
             self.metadata = None
             return
-        elif isinstance(image_obj, list) or (not image_obj and settings) or cpf.settings.is_settings(image_obj):
-             # when calling hdf5 file there is no image_obj to send (= None) and settings is
-             # provided instead. 
-             # 
-             # (any(False if x is None else "*" in x for x in self.metadata_labels.values()) or 
-             #  any(False if x is None else "/" in x for x in self.metadata_labels.values()) or 
-             #  (settings and any("*" in x for x in settings.metadata)) or 
-             #  (settings and any("/" in x for x in settings.metadata))
-             #  ):
+        elif (
+            isinstance(image_obj, list)
+            or (not image_obj and settings)
+            or cpf.settings.is_settings(image_obj)
+        ):
+            # when calling hdf5 file there is no image_obj to send (= None) and settings is
+            # provided instead.
+            #
+            # (any(False if x is None else "*" in x for x in self.metadata_labels.values()) or
+            #  any(False if x is None else "/" in x for x in self.metadata_labels.values()) or
+            #  (settings and any("*" in x for x in settings.metadata)) or
+            #  (settings and any("/" in x for x in settings.metadata))
+            #  ):
             # here we set pointers to the things needed when the metadata is read.
             # assuming that it is not wise (or possible) to list all the possible hdf5
-            # keys which could be read as metadata. 
-            
+            # keys which could be read as metadata.
+
             metadata_dictionary = {}
             if settings.subfit_filename is not None:
                 metadata_dictionary["image"] = settings.subfit_filename
             else:
                 metadata_dictionary["image"] = settings.image_list[0][0]
-            metadata_dictionary["note"] = "It is not reasonable to load all hdf5 keys into a dictionary as metadata. Instead carry file name and use keys"
-            metadata_dictionary["h5_datakey"] = settings.h5_datakey       
+            metadata_dictionary["note"] = (
+                "It is not reasonable to load all hdf5 keys into a dictionary as metadata. Instead carry file name and use keys"
+            )
+            metadata_dictionary["h5_datakey"] = settings.h5_datakey
             # add the file creation and modifications time
             # metadata_dictionary.update(self._get_file_created_modified(image_obj[0]))
         else:
             if isinstance(image_obj, str) or isinstance(image_obj, Path):
                 metadata_dictionary.update(fabio.open(image_obj).header)
             else:
-                metadata_dictionary.update(image_obj.header)       
+                metadata_dictionary.update(image_obj.header)
             # add the file creation and modifications time
             metadata_dictionary.update(self._get_file_created_modified(image_obj))
 
         if settings and "metadata_read_func" in settings.__dict__:
-            metadata_dictionary.update(settings.metadata_read_func(settings, image_obj=image_obj))     
+            metadata_dictionary.update(
+                settings.metadata_read_func(settings, image_obj=image_obj)
+            )
         self.metadata = metadata_dictionary
 
     @staticmethod
@@ -813,7 +848,9 @@ class DioptasDetector:
                 if par in required_list:
                     logger.info(" ".join(map(str, [("Got: ", par)])))
                 else:
-                    logger.info(f"The settings file requires a parameter called '{par}'")
+                    logger.info(
+                        f"The settings file requires a parameter called '{par}'"
+                    )
                     all_present = 0
             if all_present == 0:
                 sys.exit(
@@ -821,12 +858,12 @@ class DioptasDetector:
                     "are all present."
                 )
         return required_list
-    
+
     def detector_description(self):
         """
-        Returns a text description of the detector. 
-        
-        For Dioptas detectors this is called from PyFAI.  
+        Returns a text description of the detector.
+
+        For Dioptas detectors this is called from PyFAI.
 
         Returns
         -------
@@ -834,7 +871,7 @@ class DioptasDetector:
             Text description of the detector and the calibration.
         """
         description = DefaultAiWriter(None, self.detector).make_headers()
-        description = description.replace('\r\n', '\n')
+        description = description.replace("\r\n", "\n")
         return description
 
     # add common function.
@@ -849,7 +886,6 @@ class DioptasDetector:
     _reduce_array = _AngleDispersive_common._reduce_array
     get_metadata = _metadata_common.get_metadata
     _get_file_created_modified = _metadata_common._get_file_created_modified
-
 
     # add masking functions to detetor class.
     get_mask = _masks.get_mask

--- a/src/cpf/input_types/XYFunctions.py
+++ b/src/cpf/input_types/XYFunctions.py
@@ -52,8 +52,8 @@ import os
 import pickle
 import re
 import sys
-from pathlib import Path
 from copy import copy, deepcopy
+from pathlib import Path
 
 import fabio
 import matplotlib.pyplot as plt
@@ -66,11 +66,11 @@ from matplotlib import image
 from PIL import Image
 
 import cpf.h5_functions as h5_functions
-from cpf import IO_functions
 from cpf.input_types._AngleDispersive_common import _AngleDispersive_common
-from cpf.input_types._metadata_common import _metadata_common
 from cpf.input_types._Masks import _masks
+from cpf.input_types._metadata_common import _metadata_common
 from cpf.input_types._Plot_AngleDispersive import _Plot_AngleDispersive
+from cpf.util import io
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.input_types.XYFunctions")
@@ -142,11 +142,11 @@ class XYDetector:
         self.azm_end = -np.inf
         self.tth_start = None
         self.tth_end = None
-        
+
         # Image data so contonuous.
         self.Dispersion = "Angle"
         self.continuous_azm = True
-        
+
         self.Dispersionlabel = r"Pixels"
         self.DispersionUnits = r"num"
         self.Azimuthlabel = r"Pixels"
@@ -154,15 +154,16 @@ class XYDetector:
         self.Observationslabel = r"Intensity"
         self.ObservationsUnits = r"a.u."
 
-        #set defualt value, do not asume is diffraction data
+        # set defualt value, do not asume is diffraction data
         self.azm_blocks = 100
-            
+
         self.reduce_by = None
 
-        self._default_metadata_labels = {"time_label": "FILE_CREATION", # file creation time.
-                                  # 'exposure_label': None # no exposure - cant have empty value
-                                  }
-        
+        self._default_metadata_labels = {
+            "time_label": "FILE_CREATION",  # file creation time.
+            # 'exposure_label': None # no exposure - cant have empty value
+        }
+
         self.calibration = None
         self.conversion_constant = None
         self.detector = None
@@ -177,7 +178,13 @@ class XYDetector:
             if self.calibration:
                 self.detector = self.get_detector(settings=settings_class)
 
-    def duplicate(self, range_bounds=[-np.inf, np.inf], azi_bounds=[-np.inf, np.inf], with_detector=True, as_masked=False):
+    def duplicate(
+        self,
+        range_bounds=[-np.inf, np.inf],
+        azi_bounds=[-np.inf, np.inf],
+        with_detector=True,
+        as_masked=False,
+    ):
         """
         Makes an independent copy of a XYDetector Instance.
 
@@ -201,20 +208,20 @@ class XYDetector:
 
         """
 
-        #validate the ranges
+        # validate the ranges
         range_bounds, azi_bounds = self.check_bounds(range_bounds, azi_bounds)
-        
+
         if with_detector:
             new = copy(self)
         else:
-            # copy and then delete the detector and calibration, 
-            # so that anyother non-default values are propagated.             
+            # copy and then delete the detector and calibration,
+            # so that anyother non-default values are propagated.
             new = deepcopy(self)
             new.detector = None
             new.calibration = None
-            
+
             # new = XYDetector()
-            # # must define conversion constants here beacuce this is the only other 
+            # # must define conversion constants here beacuce this is the only other
             # # variable that is REQUIRED.
             # new.conversion_constant = self.conversion_constant
 
@@ -326,7 +333,8 @@ class XYDetector:
 
         if self.calibration == None:
             self.get_calibration(
-                settings=settings, file_name=calibration_file, #, debug=debug
+                settings=settings,
+                file_name=calibration_file,  # , debug=debug
             )
 
         if diffraction_data is None and settings is not None:
@@ -341,8 +349,13 @@ class XYDetector:
 
     # @staticmethod
     def import_image(
-        self, image_name=None, settings=None, mask=None, dtype=None, 
-        reduce_by = None, debug=False
+        self,
+        image_name=None,
+        settings=None,
+        mask=None,
+        dtype=None,
+        reduce_by=None,
+        debug=False,
     ):
         """
         Import the data image into the intensity array.
@@ -412,7 +425,7 @@ class XYDetector:
 
         if self.calibration["x_dim"] != 0:
             im = im.T
-            
+
         # reduce the size of the data (if called for)
         if reduce_by is not None or self.reduce_by is not None:
             if reduce_by is False:
@@ -429,7 +442,7 @@ class XYDetector:
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
             ax.imshow(im)
-            plt.title(IO_functions.title_file_names(image_name=image_name))
+            plt.title(io.title_file_names(image_name=image_name))
             plt.show()
             plt.close()
 
@@ -449,23 +462,25 @@ class XYDetector:
         im = filters.gaussian(im, sigma)
         """
 
-        #add metadata to instance.
-        #done here so only need to open file once.
+        # add metadata to instance.
+        # done here so only need to open file once.
         self._set_metadata(image_name, settings=settings)
-        
+
         # apply mask to the intensity array
         if mask == None and ma.is_masked(self.intensity) == False:
             self.intensity = ma.array(im)
             return ma.array(im)
-        elif ma.is_masked(self.intensity) == True and self.intensity.mask.shape == im.shape:
+        elif (
+            ma.is_masked(self.intensity) == True
+            and self.intensity.mask.shape == im.shape
+        ):
             # apply mask from previous intensities and all are same size
             self.intensity = ma.array(im, mask=self.intensity.mask)
             return ma.array(im)
-        else:#if mask is not None:
+        else:  # if mask is not None:
             # apply given mask
             self.intensity = ma.array(im, mask=self.get_mask(mask, im))
             return ma.array(im, mask=mask)
-
 
     def fill_data(
         self, diff_file=None, settings=None, mask=None, make_zyx=False, debug=False
@@ -522,12 +537,12 @@ class XYDetector:
 
         if settings.reduce_by is not None:
             self.reduce_by = settings.reduce_by
-        
+
         if settings.metadata_labels is not None:
             self.metadata_labels = settings.metadata_labels
         else:
             self.metadata_labels = self._default_metadata_labels
-            
+
         if self.detector == None:
             self.get_detector(settings=settings)
 
@@ -544,16 +559,16 @@ class XYDetector:
         if self.reduce_by is not None:
             self.intensity = self._reduce_array(self.intensity)
             self.tth = self._reduce_array(self.tth)
-            
+
             if "original_mask" in dir(self):
-                self.original_mask= self._reduce_array(self.original_mask)
-            
-            if (re.findall("azimuth", self.calibration["y_label"].lower())
-                or 
-                re.findall("theta", self.calibration["x_label"].lower())
-                or
-                self.azm_end == self.azm_start + 360):
-                # the data would appear to be diffraction data. 
+                self.original_mask = self._reduce_array(self.original_mask)
+
+            if (
+                re.findall("azimuth", self.calibration["y_label"].lower())
+                or re.findall("theta", self.calibration["x_label"].lower())
+                or self.azm_end == self.azm_start + 360
+            ):
+                # the data would appear to be diffraction data.
                 self.azm = self._reduce_array(self.azm, polar=True)
             else:
                 # data is some other sort of data.
@@ -561,45 +576,48 @@ class XYDetector:
 
         # get new azm_blocks from detector.
         self.azm_blocks = self.detector.azm_blocks
-        
-        self.azm_start = np.floor(np.min(self.azm.flatten()) / self.azm_blocks) * self.azm_blocks
-        self.azm_end   =  np.ceil(np.max(self.azm.flatten()) / self.azm_blocks) * self.azm_blocks
+
+        self.azm_start = (
+            np.floor(np.min(self.azm.flatten()) / self.azm_blocks) * self.azm_blocks
+        )
+        self.azm_end = (
+            np.ceil(np.max(self.azm.flatten()) / self.azm_blocks) * self.azm_blocks
+        )
         self.tth_start = np.min(self.tth.flatten())
-        self.tth_end   = np.max(self.tth.flatten())
-        
+        self.tth_end = np.max(self.tth.flatten())
+
         self.Dispersionlabel = self.detector.calibration["x_label"]
         self.DispersionUnits = self.detector.calibration["x_unit"]
         self.Azimuthlabel = self.detector.calibration["y_label"]
         self.AzimuthUnits = self.detector.calibration["y_unit"]
-     
 
     def _set_metadata(self, image_obj, settings=None):
         """
         Adds all possible metadata values as dictionary within the in the data_class.
-        
-        The values that are in settings.metadata (a list) are extracted subsequently using data_class.get_metadata 
-        
-        If the cpf settings class is provided and has the method 'metadata_read_func'
-        then this method is used to override the internal default methods and is 
-        used to create 'metadata_dictionary' which is parsed.
-        In this case the settings class attribute 'metadata_labels' is still needed 
-        to get required parts of the metadata. 
 
-        For XY functions the default is a PIL.Image.open(image_obj).tag_v2.names() dictionary 
-        
+        The values that are in settings.metadata (a list) are extracted subsequently using data_class.get_metadata
+
+        If the cpf settings class is provided and has the method 'metadata_read_func'
+        then this method is used to override the internal default methods and is
+        used to create 'metadata_dictionary' which is parsed.
+        In this case the settings class attribute 'metadata_labels' is still needed
+        to get required parts of the metadata.
+
+        For XY functions the default is a PIL.Image.open(image_obj).tag_v2.names() dictionary
+
         Parameters
         ----------
         image_obj : Path, string
             file path for the image to be opened.
         settings : cpf settings class, optional
-            If the settings class has method 'metadata_read' this overrides the 
-            internal methods and is used to get the metadata. 
+            If the settings class has method 'metadata_read' this overrides the
+            internal methods and is used to get the metadata.
             The default is None.
 
         Returns
         -------
         metadata_dictionary
-            dictionary of image metadata. 
+            dictionary of image metadata.
         """
         # Defined as function to allow get_metadata to call universal image method
         # Defined as function to allow get_metadata to call universal image method
@@ -614,14 +632,16 @@ class XYDetector:
             raise ValueError("This is the wrong method to get h5 type metadata.")
         else:
             try:
-                #try using PIL but who knows.
+                # try using PIL but who knows.
                 metadata_dictionary = Image.open(image_obj).tag_v2.names()
             except:
                 # no idea what non-image metadata will look like so pass.
                 metadata_dictionary = {}
 
         if settings and "metadata_read_func" in settings.__dict__:
-            metadata_dictionary.update(settings.metadata_read_func(settings, image_obj=image_obj))            
+            metadata_dictionary.update(
+                settings.metadata_read_func(settings, image_obj=image_obj)
+            )
         # add the file creation and modifications time
         metadata_dictionary.update(self._get_file_created_modified(image_obj))
         self.metadata = metadata_dictionary
@@ -701,11 +721,11 @@ class XYDetector:
     get_metadata = _metadata_common.get_metadata
     _get_file_created_modified = _metadata_common._get_file_created_modified
     """
-    FIXME: add more flxibility to conversion    
+    FIXME: add more flxibility to conversion
     XYFunctions does not have to be X-ray diffraction but it could be. To pass a
     empty conversion throgh the function set DataClass.conversion_factor=False.
-    But other conversions might be necessary in fiture and so the function may 
-    need further generalisationby by accepting a lambda function. 
+    But other conversions might be necessary in fiture and so the function may
+    need further generalisationby by accepting a lambda function.
     """
 
     # add masking functions to detetor class.
@@ -723,7 +743,7 @@ class XYDetector:
     plot_calibrated = _Plot_AngleDispersive.plot_calibrated
     plot_integrated = _Plot_AngleDispersive.plot_integrated
     what_plot_type = _Plot_AngleDispersive.what_plot_type
-    
+
     # this function is added because it requires access to self:
     dispersion_ticks = _Plot_AngleDispersive._dispersion_ticks
 
@@ -740,15 +760,15 @@ class OrthogonalDetector:
         self.calib = calibration
         self.max_shape = max_shape
 
-        # initiate a bunch of defaults. 
+        # initiate a bunch of defaults.
         self.calibration = {}
 
         self.calibration["x_dim"] = 0
-        self.calibration["x"] = [0,1]
+        self.calibration["x"] = [0, 1]
         self.calibration["x_start"] = np.nan
         self.calibration["x_end"] = np.nan
         self.calibration["x_scale"] = "linear"
-        self.calibration["y"] = [0,1]
+        self.calibration["y"] = [0, 1]
         self.calibration["y_start"] = np.nan
         self.calibration["y_end"] = np.nan
         self.calibration["y_scale"] = "linear"
@@ -759,9 +779,8 @@ class OrthogonalDetector:
         self.calibration["y_unit"] = "num"
         self.calibration["y_label"] = "pixels"
 
-        #set a default spacing
+        # set a default spacing
         self.azm_blocks = 100
-        
 
         self.calibration["conversion_constant"] = 1
 
@@ -836,12 +855,15 @@ class OrthogonalDetector:
             y_dim = 1
         else:
             y_dim = 0
-        
+
         if "y" in calibration:
             self.calibration["y"] = calibration["y"]
         elif "y_start" in calibration:
             self.calibration["y"][0] = self.calibration["y_start"]
-            self.calibration["y"][1] = (self.calibration["y_end"] - self.calibration["y_start"]) / (self.max_shape[y_dim] - 1),
+            self.calibration["y"][1] = (
+                (self.calibration["y_end"] - self.calibration["y_start"])
+                / (self.max_shape[y_dim] - 1),
+            )
 
         # print(self.calibration["y_label"].lower(), "azimuth", self.calibration["y_label"].lower() == "azimuth")
         if self.calibration["y_label"].lower() == "azimuth":
@@ -851,12 +873,18 @@ class OrthogonalDetector:
 
         if "theta" in self.calibration["x_label"].lower():
             if "$" not in self.calibration["x_label"].lower():
-                self.calibration["x_label"] = re.sub(r'\$\\theta\$|\\theta|theta', "$\theta$", self.calibration["x_label"].lower())
-                # force string to be a raw string. 
-                self.calibration["x_label"] = self.calibration["x_label"].encode('unicode_escape').decode()
+                self.calibration["x_label"] = re.sub(
+                    r"\$\\theta\$|\\theta|theta",
+                    "$\theta$",
+                    self.calibration["x_label"].lower(),
+                )
+                # force string to be a raw string.
+                self.calibration["x_label"] = (
+                    self.calibration["x_label"].encode("unicode_escape").decode()
+                )
             if "x_unit" not in calibration:
                 self.calibration["x_unit"] = "deg"
-            
+
         self.calibration_check
 
     def calibration_check(self):

--- a/src/cpf/output_formatters/WriteChunksTable.py
+++ b/src/cpf/output_formatters/WriteChunksTable.py
@@ -6,8 +6,8 @@ import os
 # from cpf.Cascade import read_saved_chunks
 import pandas as pd
 
-from  cpf.settings import get_settings
-from cpf.IO_functions import make_outfile_name, peak_string
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name, peak_string
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_types.WriteChunksTable")
@@ -39,8 +39,8 @@ def WriteOutput(settings, debug=False, *args, **kwargs):
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     debug : TYPE, optional
         DESCRIPTION. The default is False.
@@ -62,7 +62,6 @@ def WriteOutput(settings, debug=False, *args, **kwargs):
 
     # make sure settings is a class
     settings_class = get_settings(settings)
-
 
     file_list = setting_class.image_list
     file_number = len(file_list)

--- a/src/cpf/output_formatters/WriteCoefficientTable.py
+++ b/src/cpf/output_formatters/WriteCoefficientTable.py
@@ -3,21 +3,20 @@ __all__ = ["Requirements", "WriteOutput"]
 
 import json
 import os
-from itertools import product
 import re
+from itertools import product
 
 import numpy as np
 import pandas as pd
 
 import cpf.peak_functions as pf
-from  cpf.settings import get_settings
 from cpf.output_formatters.fits_io import ReadFits_to_dataframe
-from cpf.output_formatters.output_csv import write_csv, make_header
-from cpf.IO_functions import make_outfile_name
+from cpf.output_formatters.output_csv import make_header, write_csv
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteCoefficientTable")
-
 
 
 def Requirements():
@@ -31,7 +30,7 @@ def Requirements():
         "dp": 5,  # how many decimal points to write out
         "col_width": 15,  # default column width for csv file.
         "coefs_vals_write": "all",  # -- pick which set of coefficients to write
-        "ordering_of_output": False # Just leave as read -- otherwise list of dataframe headers to order by
+        "ordering_of_output": False,  # Just leave as read -- otherwise list of dataframe headers to order by
     }
 
     return RequiredParams, OptionalParams
@@ -45,13 +44,13 @@ def WriteOutput(
     **kwargs,
 ):
     """
-    Write coefficents from fits to table/csv file. 
-    
+    Write coefficents from fits to table/csv file.
+
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     fitStats : bool, optional
         switch to include all the fit stats in the output file. The default is True.
@@ -65,14 +64,20 @@ def WriteOutput(
     # make sure settings is a class
     settings_class = get_settings(settings)
 
-    # Parse optional parameters 
-    dp               = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
-    col_width        = settings_class.output_settings.get("col_width", Requirements()[1]["col_width"])
-    coefs_vals_write = settings_class.output_settings.get("coefs_vals_write", Requirements()[1]["coefs_vals_write"])
-    ordering_of_output = settings_class.output_settings.get("ordering_of_output", Requirements()[1]["ordering_of_output"])
-    #override with kwargs
-    dp               = kwargs.get("dp", dp)
-    col_width        = kwargs.get("col_width", col_width)
+    # Parse optional parameters
+    dp = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
+    col_width = settings_class.output_settings.get(
+        "col_width", Requirements()[1]["col_width"]
+    )
+    coefs_vals_write = settings_class.output_settings.get(
+        "coefs_vals_write", Requirements()[1]["coefs_vals_write"]
+    )
+    ordering_of_output = settings_class.output_settings.get(
+        "ordering_of_output", Requirements()[1]["ordering_of_output"]
+    )
+    # override with kwargs
+    dp = kwargs.get("dp", dp)
+    col_width = kwargs.get("col_width", col_width)
     coefs_vals_write = kwargs.get("coefs_vals_write", coefs_vals_write)
     ordering_of_output = kwargs.get("ordering_of_output", ordering_of_output)
 
@@ -82,9 +87,9 @@ def WriteOutput(
     # cut data frame
     if coefs_vals_write != "all":
         df = df[coefs_vals_write]
-    #order the rows
+    # order the rows
     if ordering_of_output:
-        df = df.sort_values(by=ordering_of_output) 
+        df = df.sort_values(by=ordering_of_output)
 
     # make filename for output
     base = settings_class.datafile_basename
@@ -100,12 +105,11 @@ def WriteOutput(
         overwrite=True,
         additional_text="all_coefficients",
     )
-    
+
     ## outfile header
-    file_header = make_header(settings_class,
-                            fits="Fit coefficients", 
-                            calc_options=None
-                            )
-    
+    file_header = make_header(
+        settings_class, fits="Fit coefficients", calc_options=None
+    )
+
     # write file using panda dataframe
     write_csv(out_file, df, headers, file_header, col_width=col_width, dp=dp)

--- a/src/cpf/output_formatters/WriteCollectionMovie.py
+++ b/src/cpf/output_formatters/WriteCollectionMovie.py
@@ -3,19 +3,20 @@ __all__ = ["Requirements", "WriteOutput"]
 
 import os
 from copy import deepcopy
-import proglog
-import matplotlib.pyplot as plt
-import numpy as np
-from moviepy.video.VideoClip import VideoClip
-# from typing import Literal, Optional
-from moviepy import ImageClip
-# from moviepy import concatenate
-from moviepy import VideoFileClip, concatenate_videoclips
 from textwrap import wrap
 
+import matplotlib.pyplot as plt
+import numpy as np
+import proglog
+
+# from typing import Literal, Optional
+# from moviepy import concatenate
+from moviepy import ImageClip, VideoFileClip, concatenate_videoclips
+from moviepy.video.VideoClip import VideoClip
+
 # import cpf.IO_functions as IO
-from  cpf.settings import get_settings
-from cpf.IO_functions import make_outfile_name, title_file_names
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name, title_file_names
 from cpf.util.logging import get_logger
 from cpf.util.output_formatters import mplfig_to_npimage
 
@@ -31,9 +32,9 @@ def Requirements():
     OptionalParams = {
         "fps": 10,  # frames per second
         "file_types": ["mp4"],  # movie file type
-        "Irange": ["pt1percentile", "99pt9percentile"], # range of colour scale
-        "plot data as": "calibrated", 
-        "plot type": "default", #"surface",
+        "Irange": ["pt1percentile", "99pt9percentile"],  # range of colour scale
+        "plot data as": "calibrated",
+        "plot type": "default",  # "surface",
     }
 
     return RequiredParams, OptionalParams
@@ -48,8 +49,8 @@ def WriteOutput(settings, debug=False, **kwargs):
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     parms_dict : TYPE
         DESCRIPTION.
@@ -70,17 +71,23 @@ def WriteOutput(settings, debug=False, **kwargs):
     settings_class = get_settings(settings)
 
     # Parse optional parameters
-    fps        = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
-    file_types = settings_class.output_settings.get("file_types", Requirements()[1]["file_types"])
-    Irange     = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
-    plot_data_as = settings_class.output_settings.get("plot data as", Requirements()[1]["plot data as"])
-    plot_type  = settings_class.output_settings.get("plot type", Requirements()[1]["plot type"])
-    #override with kwargs
-    fps        = kwargs.get("fps", fps)
+    fps = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
+    file_types = settings_class.output_settings.get(
+        "file_types", Requirements()[1]["file_types"]
+    )
+    Irange = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
+    plot_data_as = settings_class.output_settings.get(
+        "plot data as", Requirements()[1]["plot data as"]
+    )
+    plot_type = settings_class.output_settings.get(
+        "plot type", Requirements()[1]["plot type"]
+    )
+    # override with kwargs
+    fps = kwargs.get("fps", fps)
     file_types = kwargs.get("file_types", file_types)
-    Irange     = kwargs.get("Irange", Irange)
+    Irange = kwargs.get("Irange", Irange)
     plot_data_as = kwargs.get("plot_data_as", plot_data_as)
-    plot_type  = kwargs.get("plot_type", plot_type)
+    plot_type = kwargs.get("plot_type", plot_type)
 
     # make sure file_types is a list.
     if isinstance(file_types, str):
@@ -123,14 +130,12 @@ def WriteOutput(settings, debug=False, **kwargs):
     progress = proglog.default_bar_logger("bar")  # shorthand to generate a bar logger
     print("Reading images to get intensity range")
     for z in progress.iter_bar(image=range(settings_class.image_number)):
-    # for z in range(settings_class.image_number):
+        # for z in range(settings_class.image_number):
         # read data file
         settings_class.set_subpattern(z, 0)
         data_class.import_image(settings=settings_class)
         Ipctl.append(
-            np.nanpercentile(
-                np.ma.filled(data_class.intensity, np.nan), prctl
-            )
+            np.nanpercentile(np.ma.filled(data_class.intensity, np.nan), prctl)
         )
         Imin.append(np.min(data_class.intensity))
 
@@ -170,30 +175,40 @@ def WriteOutput(settings, debug=False, **kwargs):
         else:
             # nothing is done here.
             pass
-        if t==0 and isinstance(t, int):
+        if t == 0 and isinstance(t, int):
             # the first time the this function is called by VideoClip t is an integer.
             # everyother time it is a float.
             # use this to determine whether to make the colour bar or not
             cbar = None
         else:
             cbar = False
-            
+
         ax.clear()
         if plot_data_as == "calibrated":
             data_class.plot_calibrated(
-                fig_plot=fig, 
-                axis_plot=ax, 
-                show="intensity", 
+                fig_plot=fig,
+                axis_plot=ax,
+                show="intensity",
                 limits=deepcopy(lims),
-                plot_type = plot_type,
-                cbar_axes=cbar
+                plot_type=plot_type,
+                cbar_axes=cbar,
             )
         else:
             data_class.plot_collected(
-                fig_plot=fig, axis_plot=ax, show="intensity", limits=deepcopy(lims),
-                cbar_axes=cbar
+                fig_plot=fig,
+                axis_plot=ax,
+                show="intensity",
+                limits=deepcopy(lims),
+                cbar_axes=cbar,
             )
-        ax.set_title("\n".join(wrap(title_file_names(settings_for_fit=settings_class, num=int(t * fps)), 60)))
+        ax.set_title(
+            "\n".join(
+                wrap(
+                    title_file_names(settings_for_fit=settings_class, num=int(t * fps)),
+                    60,
+                )
+            )
+        )
 
         # return the figure
         return mplfig_to_npimage(fig)
@@ -210,4 +225,3 @@ def WriteOutput(settings, debug=False, **kwargs):
         logger.info(" ".join(map(str, [("Writing %s" % out_file)])))
         animation.write_videofile(out_file, fps=fps)
     animation.close()
-    

--- a/src/cpf/output_formatters/WriteDifferentialStrain.py
+++ b/src/cpf/output_formatters/WriteDifferentialStrain.py
@@ -3,21 +3,20 @@ __all__ = ["Requirements", "WriteOutput"]
 
 import json
 import os
-from itertools import product
 import re
+from itertools import product
 
 import numpy as np
 import pandas as pd
 
 import cpf.peak_functions as pf
-from cpf.settings import get_settings
 from cpf.output_formatters.fits_io import ReadFits_to_dataframe
-from cpf.output_formatters.output_csv import write_csv, make_header
-from cpf.IO_functions import make_outfile_name
+from cpf.output_formatters.output_csv import make_header, write_csv
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteCoefficientTable")
-
 
 
 def Requirements():
@@ -28,11 +27,11 @@ def Requirements():
     ]
     OptionalParams = {
         ##"Output_directory"  # if no direcrtory is specified write to current directory.
-        "SampleGeometry": "3d", # -- geometry of the sample for determining the cnetres from. 2D or 3D.
+        "SampleGeometry": "3d",  # -- geometry of the sample for determining the cnetres from. 2D or 3D.
         "SampleDeformation": "compression",  # changes calculation between 'compression' and 'extension'.
         "dp": 5,  # how many decimal points to write out
         "col_width": 15,  # default column width for csv file.
-        "ordering_of_output": False # Just leave as read -- otherwise list of dataframe headers to order by
+        "ordering_of_output": False,  # Just leave as read -- otherwise list of dataframe headers to order by
     }
     # OptionalParams = [
     #     "SampleGeometry"  # changes the strain tensor calucaltion from 2d to 3d. This determines how the cetroid and differnetial strain of the dpsaice are extracted from the fourier series.
@@ -51,12 +50,12 @@ def WriteOutput(
     **kwargs,
 ):
     """
-    Write coefficents from fits to table/csv file. 
-    
-    
+    Write coefficents from fits to table/csv file.
+
+
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     :param fitStats: DESCRIPTION, defaults to True
     :type fitStats: TYPE, optional
@@ -73,104 +72,121 @@ def WriteOutput(
     # make sure settings is a class
     settings_class = get_settings(settings)
 
-    # Parse optional parameters 
-    SampleGeometry     = settings_class.output_settings.get("SampleGeometry", Requirements()[1]["SampleGeometry"])
-    SampleDeformation  = settings_class.output_settings.get("SampleDeformation", Requirements()[1]["SampleDeformation"])
-    dp                 = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
-    col_width          = settings_class.output_settings.get("col_width", Requirements()[1]["col_width"])
-    ordering_of_output = settings_class.output_settings.get("ordering_of_output", Requirements()[1]["ordering_of_output"])
-    #override with kwargs
-    SampleGeometry     = kwargs.get("SampleGeometry", SampleGeometry)
-    SampleDeformation  = kwargs.get("SampleDeformation", SampleDeformation)
-    dp                 = kwargs.get("dp", dp)
-    col_width          = kwargs.get("col_width", col_width)
+    # Parse optional parameters
+    SampleGeometry = settings_class.output_settings.get(
+        "SampleGeometry", Requirements()[1]["SampleGeometry"]
+    )
+    SampleDeformation = settings_class.output_settings.get(
+        "SampleDeformation", Requirements()[1]["SampleDeformation"]
+    )
+    dp = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
+    col_width = settings_class.output_settings.get(
+        "col_width", Requirements()[1]["col_width"]
+    )
+    ordering_of_output = settings_class.output_settings.get(
+        "ordering_of_output", Requirements()[1]["ordering_of_output"]
+    )
+    # override with kwargs
+    SampleGeometry = kwargs.get("SampleGeometry", SampleGeometry)
+    SampleDeformation = kwargs.get("SampleDeformation", SampleDeformation)
+    dp = kwargs.get("dp", dp)
+    col_width = kwargs.get("col_width", col_width)
     ordering_of_output = kwargs.get("ordering_of_output", ordering_of_output)
     # force all the kwargs that might be needed
-    set_params = {"SampleGeometry": SampleGeometry,
-                "SampleDeformation": SampleDeformation,
-                }
+    set_params = {
+        "SampleGeometry": SampleGeometry,
+        "SampleDeformation": SampleDeformation,
+    }
     kwargs.update(set_params)
-    
-    # read the data.
-    df = ReadFits_to_dataframe(settings=settings_class, includeSeriesValues = True, includeStats=fitStats,                               
-        SampleGeometry = SampleGeometry,
-        SampleDeformation = SampleDeformation)
-    headers = list(df.columns.values)
-    #order the rows
-    if ordering_of_output:
-        df = df.sort_values(by=ordering_of_output) 
 
-    # limit dataframe to what we want to write. 
+    # read the data.
+    df = ReadFits_to_dataframe(
+        settings=settings_class,
+        includeSeriesValues=True,
+        includeStats=fitStats,
+        SampleGeometry=SampleGeometry,
+        SampleDeformation=SampleDeformation,
+    )
+    headers = list(df.columns.values)
+    # order the rows
+    if ordering_of_output:
+        df = df.sort_values(by=ordering_of_output)
+
+    # limit dataframe to what we want to write.
     # order columns to be correct also
-    headers_use =  ["num",
-                   "DataFile",        # text_file.write(("# {0:<" + str(width_fnam - 2) + "}").format("Data File" + ","))
-                   'phase', 
-                   'peak',   # text_file.write(("{0:<" + str(width_hkl) + "}").format("Peak" + ","))
-                   ]
+    headers_use = [
+        "num",
+        "DataFile",  # text_file.write(("# {0:<" + str(width_fnam - 2) + "}").format("Data File" + ","))
+        "phase",
+        "peak",  # text_file.write(("{0:<" + str(width_hkl) + "}").format("Peak" + ","))
+    ]
     headers_use += settings.metadata
     # for i in settings.metadata:
     #     if "*" in i: # wildcard in metadata name
     #         # add all wildards to RowLst
-    #         pattern = re.compile(re.sub('[*]', '([0-9a-zA-Z-+_:]*)', i))  
+    #         pattern = re.compile(re.sub('[*]', '([0-9a-zA-Z-+_:]*)', i))
     #         matches = [word for word in list(df) if pattern.match(word)]
     #         for k in matches:
     #             headers_use.append(k)
     #     else:
     #         headers_use.append(i)
-    headers_use += ["d_mean",          # text_file.write(("{0:>" + str(width_col) + "}").format("d_mean" + ","))
-                   "d_mean_err",      # text_file.write(("{0:>" + str(width_col) + "}").format("d_mean_err" + ","))
-                   'd-space4',# text_file.write(("{0:>" + str(width_col) + "}").format("d2cos" + ","))
-                   'd-space4_err',# text_file.write(("{0:>" + str(width_col) + "}").format("d2cos_err" + ","))
-                   'd-space3', # text_file.write(("{0:>" + str(width_col) + "}").format("d2sin" + ","))
-                   'd-space3_err',# text_file.write(("{0:>" + str(width_col) + "}").format("d2sin_err" + ","))
-                   # text_file.write(("{0:>" + str(width_col) + "}").format("corr coef" + ","))
-            # differential components
-                   'differential',    # text_file.write(("{0:>" + str(width_col) + "}").format("diff strain" + ","))
-                   'differential_err',# text_file.write(("{0:>" + str(width_col) + "}").format("diff s err" + ","))
-                   'orientation',     # text_file.write(("{0:>" + str(width_col) + "}").format("orientation" + ","))
-                   'orientation_err', # text_file.write(("{0:>" + str(width_col) + "}").format("orient err" + ","))
-                   'd_max',           # text_file.write(("{0:>" + str(width_col) + "}").format("d_max" + ","))
-                   'd_min',           # text_file.write(("{0:>" + str(width_col) + "}").format("d_min" + ","))
-                   'height mean',     # text_file.write(("{0:>" + str(width_col) + "}").format("mean h" + ","))
-                   'height mean err', # text_file.write(("{0:>" + str(width_col) + "}").format("h_err" + ","))
-                   'width mean',      # text_file.write(("{0:>" + str(width_col) + "}").format("mean w" + ","))
-                   'width mean err',  # text_file.write(("{0:>" + str(width_col) + "}").format("w_err" + ","))
-                   'profile mean',    # text_file.write(("{0:>" + str(width_col) + "}").format("mean p" + ","))
-                   'profile mean err',# text_file.write(("{0:>" + str(width_col) + "}").format("p0_err" + ","))
-                   ]
-    headers_rename = {'d-space4':"d2cos",
-                'd-space4_err':"d2cos_err" ,
-                'd-space3':"d2sin",
-                'd-space3_err':"d2sin_err"}
+    headers_use += [
+        "d_mean",  # text_file.write(("{0:>" + str(width_col) + "}").format("d_mean" + ","))
+        "d_mean_err",  # text_file.write(("{0:>" + str(width_col) + "}").format("d_mean_err" + ","))
+        "d-space4",  # text_file.write(("{0:>" + str(width_col) + "}").format("d2cos" + ","))
+        "d-space4_err",  # text_file.write(("{0:>" + str(width_col) + "}").format("d2cos_err" + ","))
+        "d-space3",  # text_file.write(("{0:>" + str(width_col) + "}").format("d2sin" + ","))
+        "d-space3_err",  # text_file.write(("{0:>" + str(width_col) + "}").format("d2sin_err" + ","))
+        # text_file.write(("{0:>" + str(width_col) + "}").format("corr coef" + ","))
+        # differential components
+        "differential",  # text_file.write(("{0:>" + str(width_col) + "}").format("diff strain" + ","))
+        "differential_err",  # text_file.write(("{0:>" + str(width_col) + "}").format("diff s err" + ","))
+        "orientation",  # text_file.write(("{0:>" + str(width_col) + "}").format("orientation" + ","))
+        "orientation_err",  # text_file.write(("{0:>" + str(width_col) + "}").format("orient err" + ","))
+        "d_max",  # text_file.write(("{0:>" + str(width_col) + "}").format("d_max" + ","))
+        "d_min",  # text_file.write(("{0:>" + str(width_col) + "}").format("d_min" + ","))
+        "height mean",  # text_file.write(("{0:>" + str(width_col) + "}").format("mean h" + ","))
+        "height mean err",  # text_file.write(("{0:>" + str(width_col) + "}").format("h_err" + ","))
+        "width mean",  # text_file.write(("{0:>" + str(width_col) + "}").format("mean w" + ","))
+        "width mean err",  # text_file.write(("{0:>" + str(width_col) + "}").format("w_err" + ","))
+        "profile mean",  # text_file.write(("{0:>" + str(width_col) + "}").format("mean p" + ","))
+        "profile mean err",  # text_file.write(("{0:>" + str(width_col) + "}").format("p0_err" + ","))
+    ]
+    headers_rename = {
+        "d-space4": "d2cos",
+        "d-space4_err": "d2cos_err",
+        "d-space3": "d2sin",
+        "d-space3_err": "d2sin_err",
+    }
     if fitStats == True:
         extra_headers = [
-                   'time-elapsed',    # text_file.write(("{0:>" + str(width_col) + "}").format("Time taken" + ","))
-                   'chunks-time',     # text_file.write(("{0:>" + str(width_col) + "}").format("Chunk time" + ","))
-                   'sum-residuals-squared',# text_file.write(("{0:>" + str(width_col) + "}").format("Sum Resid^2" + ","))
-                   'status',          # text_file.write(("{0:>" + str(width_col) + "}").format("Status" + ","))
-                   'function-evaluations', # text_file.write(("{0:>" + str(width_col) + "}").format("Func eval" + ","))
-                   'n-variables',     # text_file.write(("{0:>" + str(width_col) + "}").format("Num vars" + ","))
-                   'n-data',          # text_file.write(("{0:>" + str(width_col) + "}").format("Num data" + ","))
-                   'degree-of-freedom', # text_file.write(("{0:>" + str(width_col) + "}").format("Deg Freedom" + ","))
-                   'ChiSq',           # text_file.write(("{0:>" + str(width_col) + "}").format("ChiSq" + ","))
-                   'RedChiSq',        # text_file.write(("{0:>" + str(width_col) + "}").format("Red. ChiSq" + ","))
-                   'aic',
-                   'bic'  
-                   ]
+            "time-elapsed",  # text_file.write(("{0:>" + str(width_col) + "}").format("Time taken" + ","))
+            "chunks-time",  # text_file.write(("{0:>" + str(width_col) + "}").format("Chunk time" + ","))
+            "sum-residuals-squared",  # text_file.write(("{0:>" + str(width_col) + "}").format("Sum Resid^2" + ","))
+            "status",  # text_file.write(("{0:>" + str(width_col) + "}").format("Status" + ","))
+            "function-evaluations",  # text_file.write(("{0:>" + str(width_col) + "}").format("Func eval" + ","))
+            "n-variables",  # text_file.write(("{0:>" + str(width_col) + "}").format("Num vars" + ","))
+            "n-data",  # text_file.write(("{0:>" + str(width_col) + "}").format("Num data" + ","))
+            "degree-of-freedom",  # text_file.write(("{0:>" + str(width_col) + "}").format("Deg Freedom" + ","))
+            "ChiSq",  # text_file.write(("{0:>" + str(width_col) + "}").format("ChiSq" + ","))
+            "RedChiSq",  # text_file.write(("{0:>" + str(width_col) + "}").format("Red. ChiSq" + ","))
+            "aic",
+            "bic",
+        ]
         headers_use += extra_headers
-        
+
     # check that all wanted values are present
     missing_headers = list(set(headers_use) - set(list(df)))
     # if missing headers likely means no differential strains. Add list dataframe as zeros
     for i in missing_headers:
         df[i] = 0
-    df = df.loc[:, headers_use] 
-        
+    df = df.loc[:, headers_use]
+
     # cut data frame
     df = df[headers_use]
     # rename the columns
     df.rename(columns=headers_rename, inplace=True)
-    
+
     # make filename for output
     base = settings_class.datafile_basename
     if base is None:
@@ -190,15 +206,16 @@ def WriteOutput(
         overwrite=True,
         additional_text=add_text,
     )
-    
+
     ## outfile header
     calc_options = {}
     calc_options["Sample Geometry"] = SampleGeometry
     calc_options["Sample Deformation"] = SampleDeformation
-    file_header = make_header(settings_class,
-                            derived="Differnetial strains", 
-                            calc_options=calc_options,
-                            )
+    file_header = make_header(
+        settings_class,
+        derived="Differnetial strains",
+        calc_options=calc_options,
+    )
 
     # write file using panda dataframe
     write_csv(out_file, df, headers, file_header, col_width=col_width, dp=dp)

--- a/src/cpf/output_formatters/WriteFitMovie.py
+++ b/src/cpf/output_formatters/WriteFitMovie.py
@@ -9,16 +9,16 @@ import numpy as np
 import pandas as pd
 from moviepy.video.VideoClip import VideoClip
 
-from  cpf.settings import get_settings
 from cpf.BrightSpots import SpotProcess
 from cpf.data_preprocess import remove_cosmics as cosmicsimage_preprocess
-from cpf.IO_functions import (
+from cpf.output_formatters.fits_io import ReadFits_to_list
+from cpf.settings import get_settings
+from cpf.util.io import (
     figure_suptitle_space,
     make_outfile_name,
     peak_string,
     title_file_names,
 )
-from cpf.output_formatters.fits_io import ReadFits_to_list
 from cpf.util.logging import get_logger
 from cpf.util.output_formatters import mplfig_to_npimage
 from cpf.XRD_FitSubpattern import plot_FitAndModel
@@ -35,8 +35,8 @@ def Requirements():
     OptionalParams = {
         "fps": 10,  # frames per second
         "file_types": ["mp4"],  # movie file type
-        "Irange": ["pt1percentile", "99pt9percentile"], # range of colour scale
-        "plot type": "default", #"surface",
+        "Irange": ["pt1percentile", "99pt9percentile"],  # range of colour scale
+        "plot type": "default",  # "surface",
     }
 
     return RequiredParams, OptionalParams
@@ -51,8 +51,8 @@ def WriteOutput(settings, debug=False, **kwargs):
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     debug : TYPE, optional
         DESCRIPTION. The default is True.
@@ -67,24 +67,28 @@ def WriteOutput(settings, debug=False, **kwargs):
 
     # make sure settings is a class
     settings_class = get_settings(settings)
-    
+
     # Parse optional parameters
-    fps        = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
-    file_types = settings_class.output_settings.get("file_types", Requirements()[1]["file_types"])
-    Irange     = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
-    plot_type  = settings_class.output_settings.get("plot type", Requirements()[1]["plot type"])
-    #override with kwargs
-    fps        = kwargs.get("fps", fps)
+    fps = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
+    file_types = settings_class.output_settings.get(
+        "file_types", Requirements()[1]["file_types"]
+    )
+    Irange = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
+    plot_type = settings_class.output_settings.get(
+        "plot type", Requirements()[1]["plot type"]
+    )
+    # override with kwargs
+    fps = kwargs.get("fps", fps)
     file_types = kwargs.get("file_types", file_types)
-    Irange     = kwargs.get("Irange", Irange)
-    plot_type     = kwargs.get("plot type", plot_type)
+    Irange = kwargs.get("Irange", Irange)
+    plot_type = kwargs.get("plot type", plot_type)
 
     # make sure file_types is a list.
     if isinstance(file_types, str):
         file_types = [file_types]
     if not isinstance(fps, float) and not isinstance(fps, int):
         raise ValueError("The frames per second needs to be a number.")
-        
+
     # make the base file name
     base = settings_class.datafile_basename
     if base is None or len(base) == 0:
@@ -113,9 +117,9 @@ def WriteOutput(settings, debug=False, **kwargs):
     dispersion_range = [[] for i in range(len(settings_class.fit_orders))]
     for z in range(settings_class.image_number):
         settings_class.set_subpattern(z, 0)
-        # get fits 
+        # get fits
         data_fit = all_fits[z]
-        
+
         for y in range(len(data_fit)):
             dispersion_range[y].append(data_fit[y]["range"][0])
             if "data_ranges" in data_fit[y]:
@@ -209,7 +213,6 @@ def WriteOutput(settings, debug=False, **kwargs):
             settings_class.set_subpattern(y[int(t * fps)], z)
             sub_data.set_limits(range_bounds=dispersion_range[z][y[int(t * fps)]])
 
-
             # Mask the subpattern by intensity if called for
             if (
                 "imax" in settings_class.subfit_orders
@@ -227,7 +230,7 @@ def WriteOutput(settings, debug=False, **kwargs):
                 # param_lmfit=None,
                 params_dict=data_fit,
                 figure=fig,
-                plot_type = plot_type,
+                plot_type=plot_type,
                 plot_ColourRange={
                     "max": Imax[z],
                     "min": Imin[z],

--- a/src/cpf/output_formatters/WriteMultiFit.py
+++ b/src/cpf/output_formatters/WriteMultiFit.py
@@ -6,16 +6,16 @@ import os
 import numpy as np
 
 import cpf.series_functions as sf
-from  cpf.settings import get_settings
-from cpf.IO_functions import make_outfile_name
 from cpf.output_formatters.fits_io import ReadFits_to_list
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteMultiFit")
 
 
 def Requirements():
-    """ List non-universally required parameters for writing this output type. """
+    """List non-universally required parameters for writing this output type."""
 
     RequiredParams = [
         #'apparently none!
@@ -36,21 +36,21 @@ def WriteOutput(
     """
     Writes output files in style of multifit *.fit files required for polydefix
     program of Merkel and Hilairet (2015) http://dx.doi.org/10.1107/S1600576715010390.
-        
+
     A separate file is written for each diffraction pattern.
-    
+
 
     Parameters
     ----------
     settings : cpf settings class, str, Path,
-        Settings class used for fitting the data. or 
-        Path to settings_class file or 
+        Settings class used for fitting the data. or
+        Path to settings_class file or
         filename string for settings_class file
     differential_only : bool, optional
-        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series). 
+        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series).
         Ignore the offset (cos and sin parts of the Fourier series).
         The default is False.
-        
+
     Returns
     -------
     None.
@@ -61,19 +61,21 @@ def WriteOutput(
     wavelength = settings_class.data_class.conversion_constant
 
     # Parse optional parameters
-    NumAziWrite             = settings_class.output_settings.get("NumAziWrite", Requirements()[1]["NumAziWrite"])
-    #override with kwargs
-    NumAziWrite             = kwargs.get("NumAziWrite", NumAziWrite)
-    
+    NumAziWrite = settings_class.output_settings.get(
+        "NumAziWrite", Requirements()[1]["NumAziWrite"]
+    )
+    # override with kwargs
+    NumAziWrite = kwargs.get("NumAziWrite", NumAziWrite)
+
     # get the fits
     fits, _ = ReadFits_to_list(settings=settings_class)
-    
+
     for z in range(settings_class.image_number):
         settings_class.set_subpattern(z, 0)
 
         # get correct bit of data
         data_to_write = fits[z]
-        
+
         # create output file name from passed name
         base = settings_class.subfit_filename
         if base is None:

--- a/src/cpf/output_formatters/WriteOrderSearchFigures.py
+++ b/src/cpf/output_formatters/WriteOrderSearchFigures.py
@@ -1,23 +1,20 @@
 __all__ = ["Requirements", "WriteOutput"]
 
 
-import os
-
 import glob
-import numpy as np
-
+import os
 from typing import Literal, Optional
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.ticker import MaxNLocator
 
-from  cpf.settings import get_settings
 from cpf.output_formatters.fits_io import ReadFits_to_dataframe
-from cpf.IO_functions import make_outfile_name, peak_string
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name, peak_string
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteCoefficientTable")
-
 
 
 def Requirements():
@@ -28,7 +25,7 @@ def Requirements():
     ]
     OptionalParams = {
         ##"Output_directory"  # if no direcrtory is specified write to current directory.
-        #"coefs_vals_write": "given"  # -- pick which set of coefficients to write
+        # "coefs_vals_write": "given"  # -- pick which set of coefficients to write
     }
 
     return RequiredParams, OptionalParams
@@ -37,28 +34,27 @@ def Requirements():
 # def WriteOutput(FitSettings, parms_dict, **kwargs):
 def WriteOutput(
     settings,
-    file_label = None,
+    file_label=None,
     statistic: Literal["bic", "aic", "RedChiSq", "ChiSq"] = "bic",
-    key_parameter = ["d-space0", "differential"],
+    key_parameter=["d-space0", "differential"],
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
-    
     *args,
     **kwargs,
 ):
     """
-    Plots outputs of cpf.XRD_FitPattern.order_search. 
-    Outputs are an indication of what is the best order to use for a fit. 
+    Plots outputs of cpf.XRD_FitPattern.order_search.
+    Outputs are an indication of what is the best order to use for a fit.
 
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     file_label : string, optional
-        Additional text in json file name added by cpf.XRD_FitPattern.order_search(). 
+        Additional text in json file name added by cpf.XRD_FitPattern.order_search().
         If not present the default is to use the newest file. The default is None.
     *args : TYPE
         DESCRIPTION.
@@ -78,13 +74,13 @@ def WriteOutput(
 
     # make sure settings is a class
     settings_class = get_settings(settings)
-    
+
     settings_class.set_data_files(start=0, end=1)
-    
+
     if file_label is not None:
         settings_class.file_label = file_label
-    
-    #this is search data so there is a postscript in the json file label.
+
+    # this is search data so there is a postscript in the json file label.
     # determine the label
     if "file_label" not in dir(settings_class) or settings_class.file_label is None:
         fls = glob.glob("./results/*search*.json")
@@ -95,12 +91,19 @@ def WriteOutput(
             for i in range(len(fls)):
                 tm.append(os.path.getmtime(fls[i]))
             latest = np.argsort(tm)[-1]
-            settings_class.file_label = os.path.splitext(os.path.basename(fls[latest]))[0].split("__")[1]
-    
+            settings_class.file_label = os.path.splitext(os.path.basename(fls[latest]))[
+                0
+            ].split("__")[1]
+
     # read the data.
-    df = ReadFits_to_dataframe(settings=settings_class, includeStats=True, includeSeriesValues=True, includePosition=True)
+    df = ReadFits_to_dataframe(
+        settings=settings_class,
+        includeStats=True,
+        includeSeriesValues=True,
+        includePosition=True,
+    )
     headers = list(df.columns.values)
-    
+
     # split the notes column into columns and calculate some new values
     f = lambda x: x.split("|")[0].split("=")[1]
     df["search_peak"] = df["note"].apply(f).astype(int)
@@ -111,49 +114,77 @@ def WriteOutput(
     f = lambda x: x.split("|")[2].split("=")[1]
     df["series_type"] = df["note"].apply(f)
 
-    df["Fit_time_without_chunks"] = df["time-elapsed"]-df["chunks-time"]
-    df["RedChiSq_per_s"] = df["RedChiSq"]/df["Fit_time_without_chunks"]
-    
+    df["Fit_time_without_chunks"] = df["time-elapsed"] - df["chunks-time"]
+    df["RedChiSq_per_s"] = df["RedChiSq"] / df["Fit_time_without_chunks"]
+
     peaks = df["peak"].unique()
     searches = df["series_type"].unique()
-    param_plot = ["RedChiSq", "Fit_time_without_chunks", "RedChiSq_per_s", "bic", "aic", "d-space0", "time-elapsed", "chunks-time"]
-    
+    param_plot = [
+        "RedChiSq",
+        "Fit_time_without_chunks",
+        "RedChiSq_per_s",
+        "bic",
+        "aic",
+        "d-space0",
+        "time-elapsed",
+        "chunks-time",
+    ]
+
     param_plot = [statistic, "Fit_time_without_chunks"] + key_parameter
-    cols=int(2)
+    cols = int(2)
     fig_scale = 1.5
     for i in range(len(peaks)):
-        fig, ax = plt.subplots(int(np.ceil(len(param_plot))/cols), cols, sharex=True, figsize=[8*fig_scale,6*fig_scale])
+        fig, ax = plt.subplots(
+            int(np.ceil(len(param_plot)) / cols),
+            cols,
+            sharex=True,
+            figsize=[8 * fig_scale, 6 * fig_scale],
+        )
         ax = ax.flat
-        title_str = ("Order Search - " + 
-            peak_string(settings_class.subfit_orders, peak=i) +
-            " - " + df["search_over"][0]
+        title_str = (
+            "Order Search - "
+            + peak_string(settings_class.subfit_orders, peak=i)
+            + " - "
+            + df["search_over"][0]
         )
         fig.suptitle(title_str)
         for h in range(len(param_plot)):
             for j in range(len(searches)):
-                
-                df_tmp = df[(df['peak'] == peaks[i]) & (df['series_type'] == searches[j])]
-                # if there is more than 1 peak we need to filter the data to 
+                df_tmp = df[
+                    (df["peak"] == peaks[i]) & (df["series_type"] == searches[j])
+                ]
+                # if there is more than 1 peak we need to filter the data to
                 # just look at the one that has been searched over.
-                if len(df_tmp['search_peak'].unique()) == 1:
+                if len(df_tmp["search_peak"].unique()) == 1:
                     # there is only 1 peak. has to be 0.
                     k = 0
                 else:
-                    k= df_tmp['pos_in_range'].unique()[0]    
-                if param_plot[h]+"_err" in headers:
-                    ax[h].errorbar(df_tmp.loc[df_tmp['search_peak'] == k]['search_value'], 
-                                   df_tmp.loc[df_tmp['search_peak'] ==k][param_plot[h]], 
-                                   yerr =  df_tmp.loc[df_tmp['search_peak'] ==k][param_plot[h]+"_err"],
-                                   fmt='.-', capsize=5, label=searches[j])
+                    k = df_tmp["pos_in_range"].unique()[0]
+                if param_plot[h] + "_err" in headers:
+                    ax[h].errorbar(
+                        df_tmp.loc[df_tmp["search_peak"] == k]["search_value"],
+                        df_tmp.loc[df_tmp["search_peak"] == k][param_plot[h]],
+                        yerr=df_tmp.loc[df_tmp["search_peak"] == k][
+                            param_plot[h] + "_err"
+                        ],
+                        fmt=".-",
+                        capsize=5,
+                        label=searches[j],
+                    )
                 else:
-                    ax[h].plot(df_tmp.loc[df_tmp['search_peak'] == k]['search_value'], df_tmp.loc[df_tmp['search_peak'] ==k][param_plot[h]], '.-', label=searches[j])
-        
+                    ax[h].plot(
+                        df_tmp.loc[df_tmp["search_peak"] == k]["search_value"],
+                        df_tmp.loc[df_tmp["search_peak"] == k][param_plot[h]],
+                        ".-",
+                        label=searches[j],
+                    )
+
             ax[h].set_xlabel(f"{df['search_over'][0]} order")
             ax[h].xaxis.set_major_locator(MaxNLocator(integer=True))
             ax[h].set_ylabel(param_plot[h])
             # ax[h].set_title(peaks[i])
             ax[h].legend()
-        
+
         # write figures to file
         # position = df.iloc[i]["Position in json"]
         # data_fit_tmp = data_fit[position]
@@ -161,17 +192,17 @@ def WriteOutput(
         #     data_fit_tmp.pop("note")
         lbl = settings_class.file_label
         if lbl[-3:] == "all":
-            lbl = lbl[:-3]+str(i)
+            lbl = lbl[:-3] + str(i)
         lbl = peak_string(settings_class.subfit_orders, peak=i, fname=True) + "__" + lbl
         out_file = make_outfile_name(
             settings_class.subfit_filename,
             directory=settings_class.output_directory,
             # orders = data_fit_tmp,
             additional_text=lbl,
-            extension='.png',
+            extension=".png",
             peak=peaks[i],
             overwrite=True,
         )
         fig.savefig(out_file)
-            
+
     return df

--- a/src/cpf/output_formatters/WriteOrderSearchMovie.py
+++ b/src/cpf/output_formatters/WriteOrderSearchMovie.py
@@ -1,30 +1,31 @@
 __all__ = ["Requirements", "WriteOutput"]
 
-import os
 import glob
 import json
-import numpy as np
-import matplotlib.pyplot as plt
+import os
 from typing import Literal, Optional
-from moviepy import ImageClip
-# from moviepy import concatenate
-from moviepy import VideoFileClip, concatenate_videoclips
 
-from cpf.output_formatters.fits_io import ReadFits_to_dataframe
-from cpf.IO_functions import make_outfile_name
-from cpf.util.logging import get_logger
-from cpf.XRD_FitSubpattern import plot_FitAndModel
+import matplotlib.pyplot as plt
+import numpy as np
+
+# from moviepy import concatenate
+from moviepy import ImageClip, VideoFileClip, concatenate_videoclips
+
 from cpf.BrightSpots import SpotProcess
-from  cpf.settings import get_settings
-from cpf.IO_functions import (
+from cpf.output_formatters.fits_io import ReadFits_to_dataframe
+from cpf.settings import get_settings
+from cpf.util.io import (
     figure_suptitle_space,
     make_outfile_name,
     peak_string,
     title_file_names,
 )
+from cpf.util.logging import get_logger
 from cpf.util.output_formatters import mplfig_to_npimage
+from cpf.XRD_FitSubpattern import plot_FitAndModel
 
 logger = get_logger("cpf.output_formatters.WriteOrderSearchMovie")
+
 
 def Requirements():
     """
@@ -34,25 +35,25 @@ def Requirements():
     Returns
     -------
     RequiredParams : list
-        Parameters that the Output type cannot be run without, excluding the 
+        Parameters that the Output type cannot be run without, excluding the
         settings class or parameters therein.
     OptionalParams : list
         Parameters that change the output but have default settings.
     """
-    
+
     # OptionalParams is for parameters that affect the contents or types of the written files.
     # Does not contain settings related to the processing.
-    
+
     RequiredParams = [
         #'apparently none!
     ]
     OptionalParams = {
         "fps": 10,  # frames per second
         "file_types": ["mp4"],  # movie file type
-        "Irange": ["pt1percentile", "99pt9percentile"], # range of colour scale
+        "Irange": ["pt1percentile", "99pt9percentile"],  # range of colour scale
     }
 
-    # OptionalParams = [ # list of parameters parsed as kwargs. 
+    # OptionalParams = [ # list of parameters parsed as kwargs.
     #     "file_types"  # -- pick which type of movis to write
     #     "fps"         # -- frames per second
     # ]
@@ -61,7 +62,7 @@ def Requirements():
 
 def WriteOutput(
     settings,
-    file_label = None,
+    file_label=None,
     report: Literal[
         "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
     ] = "INFO",
@@ -72,12 +73,12 @@ def WriteOutput(
     Writes a movie file of the outputs from cpf.XRD_FitPattern.order_search.
 
     N.B. this output requires the data files to be present.
-    
+
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     file_label : str, optional
         String added to the names of the files made. The default is None.
@@ -101,16 +102,18 @@ def WriteOutput(
 
     # make sure settings is a class
     settings_class = get_settings(settings)
-    
+
     # Parse optional parameters
-    fps        = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
-    file_types = settings_class.output_settings.get("file_types", Requirements()[1]["file_types"])
-    Irange     = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
-    #override with kwargs
-    fps        = kwargs.get("fps", fps)
+    fps = settings_class.output_settings.get("fps", Requirements()[1]["fps"])
+    file_types = settings_class.output_settings.get(
+        "file_types", Requirements()[1]["file_types"]
+    )
+    Irange = settings_class.output_settings.get("Irange", Requirements()[1]["Irange"])
+    # override with kwargs
+    fps = kwargs.get("fps", fps)
     file_types = kwargs.get("file_types", file_types)
-    Irange     = kwargs.get("Irange", Irange)
-        
+    Irange = kwargs.get("Irange", Irange)
+
     if not isinstance(file_types, list):
         file_types = [file_types]
     if not (isinstance(fps, float) or isinstance(fps, int)):
@@ -127,10 +130,10 @@ def WriteOutput(
         settings=settings_class,
     )
 
-    #restrict to just the first file (as per order search)
+    # restrict to just the first file (as per order search)
     settings_class.set_data_files(start=0, end=1)
-    
-    #this is search data so there is a postscript in the json file label.
+
+    # this is search data so there is a postscript in the json file label.
     # determine the label
     if "file_label" not in dir(settings_class) or settings_class.file_label is None:
         fls = glob.glob("./results/*search*.json")
@@ -141,10 +144,18 @@ def WriteOutput(
             for i in range(len(fls)):
                 tm.append(os.path.getmtime(fls[i]))
             latest = np.argsort(tm)[-1]
-            settings_class.file_label = os.path.splitext(os.path.basename(fls[latest]))[0].split("__")[1]
-    
+            settings_class.file_label = os.path.splitext(os.path.basename(fls[latest]))[
+                0
+            ].split("__")[1]
+
     # read the data.
-    df = ReadFits_to_dataframe(settings=settings_class, includeStats=True, includeSeriesValues=True, includeIntensityRanges=True, includePosition=True)
+    df = ReadFits_to_dataframe(
+        settings=settings_class,
+        includeStats=True,
+        includeSeriesValues=True,
+        includeIntensityRanges=True,
+        includePosition=True,
+    )
     headers = list(df.columns.values)
     # split the notes column into columns and calculate some new values
     f = lambda x: x.split("|")[0].split("=")[1]
@@ -155,12 +166,12 @@ def WriteOutput(
     df["search_value"] = df["note"].apply(f).astype(int)
     f = lambda x: x.split("|")[2].split("=")[1]
     df["series_type"] = df["note"].apply(f)
-    
+
     peaks = df["peak"].unique()
     searches = df["series_type"].unique()
     search_value = df["search_value"].unique()
-    
-    #open data file for plotting information
+
+    # open data file for plotting information
     # read fit file
     json_file = make_outfile_name(
         settings_class.subfit_filename,
@@ -171,71 +182,82 @@ def WriteOutput(
     )
     with open(json_file) as json_data:
         data_fit = json.load(json_data)
-       
-    #make movies
+
+    # make movies
     for i in range(len(peaks)):
         # loop over the number of unique peaks
-        
-        # FIXME: here we are looping over every occurence but if there are multiple peaks in a 
-        # range we could be making the videos more than once. So need to check and make 
+
+        # FIXME: here we are looping over every occurence but if there are multiple peaks in a
+        # range we could be making the videos more than once. So need to check and make
         # video for only the peak that is being searched over
         # this requires filtering for a change in search value.
-        
-        # use pos_in_range and _search peak to restrict values to the peak that 
+
+        # use pos_in_range and _search peak to restrict values to the peak that
         # is being searched over -- for multiple peaks in range
-        df_peak = df[(df['peak'] == peaks[i]) & (df['pos_in_range'] == df['search_peak'])]
-                
-        # make sure that we have only the peak that we are looping over. 
-        if len(df_peak['search_peak'].unique()) != 1:
+        df_peak = df[
+            (df["peak"] == peaks[i]) & (df["pos_in_range"] == df["search_peak"])
+        ]
+
+        # make sure that we have only the peak that we are looping over.
+        if len(df_peak["search_peak"].unique()) != 1:
             raise ValueError("There should be more than 1 peak in here somewhere")
-        
-        #sort the data into a sensible order
-        df_peak = df_peak.sort_values(['series_type', 'search_value'])
-        
-        # get the intensity ranges. 
-        Intensity_range = [np.nanmin([df_peak["data_min"], df_peak["model_min"]]), np.nanmax([df_peak["data_max"], df_peak["model_max"]])]
-        Resid_range = [np.nanmin([df_peak["residual_min"]]), np.nanmax([df_peak["residual_max"]])]
-             
-        #setup figure
+
+        # sort the data into a sensible order
+        df_peak = df_peak.sort_values(["series_type", "search_value"])
+
+        # get the intensity ranges.
+        Intensity_range = [
+            np.nanmin([df_peak["data_min"], df_peak["model_min"]]),
+            np.nanmax([df_peak["data_max"], df_peak["model_max"]]),
+        ]
+        Resid_range = [
+            np.nanmin([df_peak["residual_min"]]),
+            np.nanmax([df_peak["residual_max"]]),
+        ]
+
+        # setup figure
         fig = plt.figure()
-        
-        
+
         # interate over the length of the selection of peaks in df_peak
         frames = []
         for j in range(len(df_peak)):
-            
             # get position in data frame
             position = df_peak.iloc[j]["Position in json"]
             # print(j, position)
             # position = df_peak["Position in json"].iloc[j]
-            
+
             settings_class.set_subpattern(0, position)
-            
+
             # print(j, position)
-            
-            sub_data = data_class.duplicate_without_detector(range_bounds=[df_peak["range_start"].iloc[j], df_peak["range_end"].iloc[j]])
+
+            sub_data = data_class.duplicate_without_detector(
+                range_bounds=[
+                    df_peak["range_start"].iloc[j],
+                    df_peak["range_end"].iloc[j],
+                ]
+            )
             # sub_data = data_class.duplicate()
             # sub_data.set_limits(range_bounds=[df_peak["Range_start"].iloc[j], df_peak["Range_end"].iloc[j]])
-            
+
             # Mask the subpattern by intensity if called for
             if (
                 "imax" in settings_class.subfit_orders
                 or "imin" in settings_class.subfit_orders
             ):
                 sub_data = SpotProcess(sub_data, settings_class)
-                
+
             # get position in original input file. (before order search)
             # basically set the correct subpattern
             if len(settings_class.fit_orders) == len(df):
-                # the rows correspond 
-                settings_class.set_subpattern(0, j)    
+                # the rows correspond
+                settings_class.set_subpattern(0, j)
             else:
                 # find the row in which the phases corrospond
                 for m in range(len(settings_class.fit_orders)):
                     if peaks[i] in peak_string(settings_class.fit_orders[m]):
                         settings_class.set_subpattern(0, m)
                         # print("subpattern", m)
-            
+
             # fig = plt.figure()
             # make the plot of the fits.
             fig = plot_FitAndModel(
@@ -267,16 +289,13 @@ def WriteOutput(
             #     # print("who knows")
             #     pass
             # make the video clip
-            # just addes the figure as a frame to the proto-video. 
-            frames.append(ImageClip(mplfig_to_npimage(fig)).with_duration(1))        
+            # just addes the figure as a frame to the proto-video.
+            frames.append(ImageClip(mplfig_to_npimage(fig)).with_duration(1))
 
         # convert to video and write
-        video = concatenate_videoclips(frames, method='compose')
+        video = concatenate_videoclips(frames, method="compose")
         for f in range(len(file_types)):
-            settings_class.file_label = (
-                "search="
-                + df["search_over"][position]
-            )
+            settings_class.file_label = "search=" + df["search_over"][position]
             # make videofile name
             data_fit_tmp = data_fit["fits"][position]
             if "note" in data_fit_tmp:
@@ -284,11 +303,10 @@ def WriteOutput(
             out_file = make_outfile_name(
                 settings_class.subfit_filename,
                 directory=settings_class.output_directory,
-                orders = data_fit_tmp,
+                orders=data_fit_tmp,
                 additional_text=settings_class.file_label,
                 extension=file_types[f],
                 peak=df_peak["search_peak"].iloc[0],
                 overwrite=True,
             )
             video.write_videofile(out_file, fps=fps)
-            

--- a/src/cpf/output_formatters/WritePolydefix.py
+++ b/src/cpf/output_formatters/WritePolydefix.py
@@ -241,7 +241,7 @@ def WriteOutput(
                     hkl = "000"
                     use = 0
 
-                hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)[0]
+                hkl = peak_hkl(settings_class.fit_orders[x], peak=y, as_string=False)[0]
                 h, k, l = hkl
 
                 text_file.write(" %5i    %s    %s    %s\n" % (use, h, k, l))

--- a/src/cpf/output_formatters/WritePolydefix.py
+++ b/src/cpf/output_formatters/WritePolydefix.py
@@ -1,17 +1,18 @@
 __all__ = ["Requirements", "WriteOutput"]
 
+import glob
 import json
 import os
-import glob
 from pathlib import Path
 
 import numpy as np
 
 import cpf.output_formatters.WriteMultiFit as WriteMultiFit
+from cpf.output_formatters.fits_io import ReadFits_to_dataframe, ReadFits_to_list
+
 # from cpf.output_formatters.crystallographic_operations import plane_indices_4_to_3
 from cpf.settings import get_settings
-from cpf.IO_functions import make_outfile_name, peak_hkl
-from cpf.output_formatters.fits_io import ReadFits_to_list, ReadFits_to_dataframe
+from cpf.util.io import make_outfile_name, peak_hkl
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WritePolydefix")
@@ -23,11 +24,11 @@ def Requirements():
     RequiredParams = [
         #'apparently none!
     ]
-    OptionalParams = { # dictionary
+    OptionalParams = {  # dictionary
         # "time": "time_label", # time stamps for the diffraction paterns
-        # "temperature": "*tc1_calcs.I", # which thermocouple to call.       
+        # "temperature": "*tc1_calcs.I", # which thermocouple to call.
         "Phase": True,  # the phase we are interested in -- if True then guesses most common phase
-        "ElasticProperties": True, # default is to use the phase name of the material. If more than 1 material need wild cards to match phase names. 
+        "ElasticProperties": True,  # default is to use the phase name of the material. If more than 1 material need wild cards to match phase names.
         "differential_only": False,
         # "which_thermocouple": 1,  # which thermocoule to include from 6BMB/X17B2 collection system. default to 1. #FIX ME: this needs to be included
         ###"Output_directory",  # if no direcrtory is specified write to current directory.
@@ -64,22 +65,22 @@ def WriteOutput(
     **kwargs,
 ):
     """
-    Writes *.exp files required by polydefix. 
+    Writes *.exp files required by polydefix.
     Calls WriteMltiFit to create *.fit files needed by polydefix
-    
+
     Polydefix: Merkel and Hilairet (2015) http://dx.doi.org/10.1107/S1600576715010390.
-    
+
     N.B. this is a different file than that required by polydefix for energy dispersive diffraction.
-    
+
     Parameters
     ----------
     settings_class : cpf settings class
         Settings class used for fitting the data.
     differential_only : bool, optional
-        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series). 
+        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series).
         Ignore the offset (cos and sin parts of the Fourier series).
         The default is False.
-        
+
     Returns
     -------
     None.
@@ -89,15 +90,18 @@ def WriteOutput(
     settings_class = get_settings(settings)
 
     # Parse optional parameters
-    Phase             = settings_class.output_settings.get("Phase", Requirements()[1]["Phase"])
-    ElasticProperties = settings_class.output_settings.get("ElasticProperties", Requirements()[1]["ElasticProperties"])
-    differential_only = settings_class.output_settings.get("differential_only", Requirements()[1]["differential_only"])
-    #override with kwargs
-    Phase             = kwargs.get("Phase", Phase)
+    Phase = settings_class.output_settings.get("Phase", Requirements()[1]["Phase"])
+    ElasticProperties = settings_class.output_settings.get(
+        "ElasticProperties", Requirements()[1]["ElasticProperties"]
+    )
+    differential_only = settings_class.output_settings.get(
+        "differential_only", Requirements()[1]["differential_only"]
+    )
+    # override with kwargs
+    Phase = kwargs.get("Phase", Phase)
     ElasticProperties = kwargs.get("ElasticProperties", ElasticProperties)
     differential_only = kwargs.get("differential_only", differential_only)
-    
-        
+
     # write *.fit files
     WriteMultiFit.WriteOutput(
         settings_class, differential_only=differential_only, debug=debug
@@ -106,21 +110,20 @@ def WriteOutput(
     # get the fits
     fits, _ = ReadFits_to_list(settings=settings_class)
     fitsDF = ReadFits_to_dataframe(settings=settings_class)
-    
-    #parse Phase and ElasticProperties
+
+    # parse Phase and ElasticProperties
     if Phase is True:
-       phases = fitsDF["phase"].unique()
-       num_occurences = []
-       for i in phases:
-           num_occurences.append(fitsDF["phase"].str.count(i).sum())
-       Phase = [phases[num_occurences.index(max(num_occurences))]] 
+        phases = fitsDF["phase"].unique()
+        num_occurences = []
+        for i in phases:
+            num_occurences.append(fitsDF["phase"].str.count(i).sum())
+        Phase = [phases[num_occurences.index(max(num_occurences))]]
     elif isinstance(Phase, str):
         Phase = [Phase]
     else:
-        #phase is a list
+        # phase is a list
         pass
-    
-    
+
     base = settings_class.datafile_basename
     if base is None:
         logger.info(
@@ -134,17 +137,17 @@ def WriteOutput(
     for i in range(len(Phase)):
         fnam = base
         add_txt = None
-        
+
         if len(Phase) > 1:
             add_txt = Phase[i]
         else:
-            add_txt = None # because Files = 1
+            add_txt = None  # because Files = 1
         out_file = make_outfile_name(
             fnam,
             directory=settings_class.output_directory,  # directory=FitSettings.Output_directory,
             extension=".exp",
             overwrite=True,
-            additional_text=add_txt
+            additional_text=add_txt,
         )
         text_file = open(out_file, "w")
         logger.info(" ".join(map(str, [("Writing %s" % out_file)])))
@@ -217,14 +220,13 @@ def WriteOutput(
         text_file.write("# Peaks info (use, h, k, l)\n")
         for x in range(len(settings_class.fit_orders)):
             for y in range(len(settings_class.fit_orders[x]["peak"])):
-                
                 # FIXME: use this line below as a shortening for all the x and y pointers
                 settings_class.set_subpattern(i, x)
-                
+
                 use = 1
                 if Phase[i] != settings_class.fit_orders[x]["peak"][y]["phase"]:
                     use = 0
-                
+
                 # check if the d-spacing fits are NaN or not. if NaN switch off.
                 if type(fits[i][x]["peak"][y]["d-space"][0]) == type(None) or np.isnan(
                     fits[i][x]["peak"][y]["d-space"][0]
@@ -238,18 +240,18 @@ def WriteOutput(
                 else:
                     hkl = "000"
                     use = 0
-                    
+
                 hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)[0]
-                h,k,l = hkl
-                
+                h, k, l = hkl
+
                 text_file.write(" %5i    %s    %s    %s\n" % (use, h, k, l))
 
         # material properties
         text_file.write("# Material properties\n")
-        
+
         if ElasticProperties:
             if ElasticProperties is True or ElasticProperties == Phase[i]:
-                #use phase name to get elastic properties
+                # use phase name to get elastic properties
                 fname = glob.glob(f"*{Phase[i]}*")
             elif isinstance(ElasticProperties, str) and "*" in ElasticProperties:
                 fname = glob.glob(ElasticProperties)
@@ -257,13 +259,13 @@ def WriteOutput(
                 fname = ElasticProperties
             if isinstance(fname, list):
                 if len(fname) == 1:
-                    fname= fname[0]
+                    fname = fname[0]
                 else:
                     raise ValueError("More than 1 property file has been identified.")
-            fid = open(fname, "r")     
+            fid = open(fname, "r")
             # pipe ealstic properties to the output file.
-            text_file.write(fid.read())   
-            
+            text_file.write(fid.read())
+
         elif not Phase:
             # left empty on purpose
             text_file.write("")

--- a/src/cpf/output_formatters/WritePolydefixED.py
+++ b/src/cpf/output_formatters/WritePolydefixED.py
@@ -11,7 +11,7 @@ import numpy as np
 import cpf.series_functions as sf
 from cpf.output_formatters.fits_io import ReadFits_to_list
 from cpf.settings import get_settings
-from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
+from cpf.util.io import make_outfile_name, peak_hkl, replace_value
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WritePolydefixED")
@@ -422,7 +422,7 @@ def WriteOutput(
                 az = settings_class.data_class.calibration["azimuths"]
                 coef_type = sf.get_params_type(fit[x], "d", peak=y)
 
-                d_coef = replace_null_terms(fit[x]["peak"][y]["d-space"])
+                d_coef = replace_value(fit[x]["peak"][y]["d-space"])
                 if differential_only is True:
                     d_coef[1] = 0  #
                     d_coef[2] = 0
@@ -436,7 +436,7 @@ def WriteOutput(
                 coef_type = sf.get_params_type(fit[x], "h", peak=y)
                 peak_i = sf.coefficient_expand(
                     np.array(az_used) * sym,
-                    replace_null_terms(fit[x]["peak"][y]["height"]),
+                    replace_value(fit[x]["peak"][y]["height"]),
                     coeff_type=coef_type,
                 )
                 n = -1

--- a/src/cpf/output_formatters/WritePolydefixED.py
+++ b/src/cpf/output_formatters/WritePolydefixED.py
@@ -204,7 +204,7 @@ def WriteOutput(
             else:
                 use = 1
 
-            hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)[0]
+            hkl = peak_hkl(settings_class.fit_orders[x], peak=y, as_string=False)[0]
             h, k, l = hkl
 
             text_file.write(" %5i %5i    %s    %s    %s\n" % (peak, use, h, k, l))
@@ -406,7 +406,9 @@ def WriteOutput(
                 # [peak number     H     K     L     d-spacing     Intensity     detector number     step number   ]  in data set.
 
                 if "hkl" in settings_class.fit_orders[x]["peak"][y]:
-                    hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)
+                    hkl = peak_hkl(
+                        settings_class.fit_orders[x], peak=y, as_string=False
+                    )
                     h = hkl[0][0]
                     k = hkl[0][1]
                     l = hkl[0][2]

--- a/src/cpf/output_formatters/WritePolydefixED.py
+++ b/src/cpf/output_formatters/WritePolydefixED.py
@@ -422,7 +422,7 @@ def WriteOutput(
                 az = settings_class.data_class.calibration["azimuths"]
                 coef_type = sf.get_params_type(fit[x], "d", peak=y)
 
-                d_coef = replace_value(fit[x]["peak"][y]["d-space"])
+                d_coef = replace_value(fit[x]["peak"][y]["d-space"], old=None, new=0)
                 if differential_only is True:
                     d_coef[1] = 0  #
                     d_coef[2] = 0
@@ -436,7 +436,7 @@ def WriteOutput(
                 coef_type = sf.get_params_type(fit[x], "h", peak=y)
                 peak_i = sf.coefficient_expand(
                     np.array(az_used) * sym,
-                    replace_value(fit[x]["peak"][y]["height"]),
+                    replace_value(fit[x]["peak"][y]["height"], old=None, new=0),
                     coeff_type=coef_type,
                 )
                 n = -1

--- a/src/cpf/output_formatters/WritePolydefixED.py
+++ b/src/cpf/output_formatters/WritePolydefixED.py
@@ -1,34 +1,34 @@
 __all__ = ["Requirements", "WriteOutput"]
 
 
+import glob
 import os
 import re
-import glob
+
+import dateutil.parser as parser
 import numpy as np
 
 import cpf.series_functions as sf
 from cpf.output_formatters.fits_io import ReadFits_to_list
-from cpf.IO_functions import make_outfile_name, replace_null_terms, peak_hkl
-from  cpf.settings import get_settings
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
 from cpf.util.logging import get_logger
-
-import dateutil.parser as parser
 
 logger = get_logger("cpf.output_formatters.WritePolydefixED")
 
 
 def Requirements():
-    """ List non-universally required parameters for writing this output type. """
-    RequiredParams = [ # list
+    """List non-universally required parameters for writing this output type."""
+    RequiredParams = [  # list
         # these parameters are names in metadata labels.
         "time",
-        "temperature"
+        "temperature",
     ]
-    OptionalParams = { # dictionary
+    OptionalParams = {  # dictionary
         # "time": "time_label", # time stamps for the diffraction paterns
-        # "temperature": "*tc1_calcs.I", # which thermocouple to call.       
+        # "temperature": "*tc1_calcs.I", # which thermocouple to call.
         "Phase": True,  # the phase we are interested in -- if True then guesses nost common phase
-        "ElasticProperties": "phase_name", # default is to use the phase name of the material
+        "ElasticProperties": "phase_name",  # default is to use the phase name of the material
         "differential_only": False,
         # "which_thermocouple": 1,  # which thermocoule to include from 6BMB/X17B2 collection system. default to 1. #FIX ME: this needs to be included
         ###"Output_directory",  # if no direcrtory is specified write to current directory.
@@ -47,23 +47,23 @@ def WriteOutput(
 ):
     """
     Writes *.exp files required by polydefixED.
-    
+
     N.B. this is a different file than that required by polydefix for monochromatic diffraction.
     This file contains a list of all the diffraction information. Hence it has to be written after the fitting as a single operation.
-    
+
     Polydefix: Merkel and Hilairet (2015) http://dx.doi.org/10.1107/S1600576715010390.
-    
+
     N.B. this is a different file than that required by polydefix for energy dispersive diffraction.
-    
+
     Parameters
     ----------
     settings_class : cpf settings class
         Settings class used for fitting the data.
     differential_only : bool, optional
-        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series). 
+        Only include the differential part of the strain (cos^2 and sin^2 parts of the Fourier series).
         Ignore the offset (cos and sin parts of the Fourier series).
         The default is False.
-        
+
     Returns
     -------
     None.
@@ -86,22 +86,26 @@ def WriteOutput(
         )
 
     # Parse optional parameters
-    Phase             = settings_class.output_settings.get("Phase", Requirements()[1]["Phase"])
-    ElasticProperties = settings_class.output_settings.get("ElasticProperties", Requirements()[1]["ElasticProperties"])
-    differential_only = settings_class.output_settings.get("differential_only", Requirements()[1]["differential_only"])
-    #override with kwargs
-    Phase             = kwargs.get("Phase", Phase)
+    Phase = settings_class.output_settings.get("Phase", Requirements()[1]["Phase"])
+    ElasticProperties = settings_class.output_settings.get(
+        "ElasticProperties", Requirements()[1]["ElasticProperties"]
+    )
+    differential_only = settings_class.output_settings.get(
+        "differential_only", Requirements()[1]["differential_only"]
+    )
+    # override with kwargs
+    Phase = kwargs.get("Phase", Phase)
     ElasticProperties = kwargs.get("ElasticProperties", ElasticProperties)
     differential_only = kwargs.get("differential_only", differential_only)
-    
+
     if "Material" in settings_class.output_settings:
         raise ValueError(
             "''Material'' is depreciated as an option. Change your input file to have a ''Phase'' or ''ElasticProperties'' instead."
         )
-   
+
     # get the fits
     all_fits, metadata = ReadFits_to_list(settings=settings_class)
- 
+
     base = settings_class.datafile_basename
     if base is None:
         logger.info("No base filename, using input filename instead.")
@@ -148,7 +152,7 @@ def WriteOutput(
     for x in range(len(settings_class.data_class.calibration["azimuths"])):
         # determine if detector masked
         if settings_class.calibration_mask is not None:
-            if x+1 in settings_class.calibration_mask:
+            if x + 1 in settings_class.calibration_mask:
                 use = 0
             else:
                 use = 1
@@ -171,7 +175,7 @@ def WriteOutput(
     text_file.write("# Peak information \n")
     text_file.write("# Number. use (1/0). h. k. l\n")
     peak = 1
-    #get phase to use
+    # get phase to use
     if isinstance(Phase, str):
         phase_name = Phase
     else:
@@ -181,12 +185,11 @@ def WriteOutput(
             for y in range(len(settings_class.fit_orders[x]["peak"])):
                 phase_name.append(settings_class.fit_orders[x]["peak"][y]["phase"])
         phase_name = max(set(phase_name), key=phase_name.count)
-    
+
     for x in range(num_subpatterns):
-        
         # get fits for here
         fit = all_fits[x]
-        
+
         for y in range(len(settings_class.fit_orders[x]["peak"])):
             if "hkl" in settings_class.fit_orders[x]["peak"][y]:
                 hkl = str(settings_class.fit_orders[x]["peak"][y]["hkl"])
@@ -194,16 +197,16 @@ def WriteOutput(
                 hkl = "000"
             # check if the d-spacing fits are NaN or not. if NaN switch off.
             if np.all(fit[x]["peak"][y]["d-space"]) == None or np.isnan(
-                fit[x]["peak"][y]["d-space"][0] or 
-                fit[x]["peak"][y]["phase"] != phase_name
+                fit[x]["peak"][y]["d-space"][0]
+                or fit[x]["peak"][y]["phase"] != phase_name
             ):
                 use = 0
             else:
                 use = 1
 
             hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)[0]
-            h,k,l = hkl
-            
+            h, k, l = hkl
+
             text_file.write(" %5i %5i    %s    %s    %s\n" % (peak, use, h, k, l))
             peak = peak + 1
 
@@ -221,10 +224,9 @@ def WriteOutput(
     text_file.write("# Version\n")
     text_file.write("2       \n")
 
-        
     if ElasticProperties:
         if ElasticProperties is True or ElasticProperties == Phase:
-            #use phase name to get elastic properties
+            # use phase name to get elastic properties
             fname = glob.glob(f"*{Phase}*")
         elif isinstance(ElasticProperties, str) and "*" in ElasticProperties:
             fname = glob.glob(ElasticProperties)
@@ -232,17 +234,17 @@ def WriteOutput(
             fname = ElasticProperties
         if isinstance(fname, list):
             if len(fname) == 1:
-                fname= fname[0]
+                fname = fname[0]
             else:
                 raise ValueError("More than 1 property file has been identified.")
-        fid = open(fname, "r")     
+        fid = open(fname, "r")
         # pipe ealstic properties to the output file.
-        text_file.write(fid.read())     
-        
+        text_file.write(fid.read())
+
     elif not Phase:
         # left empty on purpose
         text_file.write("")
-        
+
     else:
         # FIX ME: here I am just writing the elastic properties of olivine with no regard for the structure of the file or the avaliable data.
         #         This should really be fixed.
@@ -333,7 +335,7 @@ def WriteOutput(
         temp = np.array(
             0.0
         )  # pre-set temperature to 0 incase no value is found in the data file.
-        
+
         tm = settings_class.metadata_labels["time"]
         # time has to be in the metadata so just get it.
         if tm in metadata[x]:
@@ -348,16 +350,24 @@ def WriteOutput(
         if not isinstance(t, float):
             # then must be a datetime.timedelta
             t = t.seconds
-        
+
         # get label for temperature. Should work for wild cards
         if "temperature" in settings_class.metadata_labels:
-            templbl_without_wildcards = re.sub(r"\*", ".*", settings_class.metadata_labels["temperature"])
+            templbl_without_wildcards = re.sub(
+                r"\*", ".*", settings_class.metadata_labels["temperature"]
+            )
         else:
-            templbl_without_wildcards = re.sub(r"\*", ".*", settings_class.data_class._default_metadata_labels["temperature"])
+            templbl_without_wildcards = re.sub(
+                r"\*",
+                ".*",
+                settings_class.data_class._default_metadata_labels["temperature"],
+            )
         r = re.compile(templbl_without_wildcards)
-        templbl = list(filter(r.match, list(metadata[0]))) # Read Note below
+        templbl = list(filter(r.match, list(metadata[0])))  # Read Note below
         if len(templbl) > 1:
-            err_str = "More than one temprature has been found. Assuming the first one. "
+            err_str = (
+                "More than one temprature has been found. Assuming the first one. "
+            )
             logger.error(err_str)
         templbl = templbl[0]
         # get temperature
@@ -396,7 +406,7 @@ def WriteOutput(
                 # [peak number     H     K     L     d-spacing     Intensity     detector number     step number   ]  in data set.
 
                 if "hkl" in settings_class.fit_orders[x]["peak"][y]:
-                    hkl = peak_hkl(settings_class.fit_orders[x], peak = y, string=False)
+                    hkl = peak_hkl(settings_class.fit_orders[x], peak=y, string=False)
                     h = hkl[0][0]
                     k = hkl[0][1]
                     l = hkl[0][2]
@@ -411,12 +421,12 @@ def WriteOutput(
 
                 az = settings_class.data_class.calibration["azimuths"]
                 coef_type = sf.get_params_type(fit[x], "d", peak=y)
-                
+
                 d_coef = replace_null_terms(fit[x]["peak"][y]["d-space"])
                 if differential_only is True:
                     d_coef[1] = 0  #
                     d_coef[2] = 0
-                
+
                 peak_d = sf.coefficient_expand(
                     np.array(az),
                     d_coef,

--- a/src/cpf/output_formatters/WritePressureStresses.py
+++ b/src/cpf/output_formatters/WritePressureStresses.py
@@ -10,9 +10,9 @@ import numpy as np
 import pandas as pd
 
 from cpf.output_formatters.convert_fit_to_unitcell import fits_to_unitcell
-from cpf.IO_functions import make_outfile_name
-from cpf.output_formatters.output_csv import write_csv, make_header
+from cpf.output_formatters.output_csv import make_header, write_csv
 from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteCoefficientTable")
@@ -27,14 +27,14 @@ def Requirements():
     OptionalParams = {
         ##"Output_directory"  # if no direcrtory is specified write to current directory.
         "reflections_to_use": "all",  # -- pick which set of reflections to use for unit cell volume
-        "phase": True, # -- pick whick phase to fit unit cell for.
-        "SampleGeometry": "3d", # -- geometry of the sample for determining the cnetres from. 2D or 3D.
+        "phase": True,  # -- pick whick phase to fit unit cell for.
+        "SampleGeometry": "3d",  # -- geometry of the sample for determining the cnetres from. 2D or 3D.
         "SampleDeformation": "compression",  # changes calculation between 'compression' and 'extension'.
         "includeUnitCells": True,
-        "weighted": True, # -- weighted fit or not. True/False
+        "weighted": True,  # -- weighted fit or not. True/False
         "dp": 5,  # how many decimal points to write out
         "col_width": 15,  # default column width for csv file.
-        "ordering_of_output": None # Just leave as read -- otherwise list of dataframe headers to order by
+        "ordering_of_output": None,  # Just leave as read -- otherwise list of dataframe headers to order by
     }
     # [
     #     ##"Output_directory"  # if no direcrtory is specified write to current directory.
@@ -55,12 +55,12 @@ def WriteOutput(
     **kwargs,
 ):
     """
-    Write pressure and stresses derived from fitted peaks. Writes the values 
-    to table/csv file. 
+    Write pressure and stresses derived from fitted peaks. Writes the values
+    to table/csv file.
 
     Parameters
     ----------
-    settings : cpf.settings.Settings() class 
+    settings : cpf.settings.Settings() class
         input file or settings class used to make the fits.
     *args : TYPE
         DESCRIPTION.
@@ -72,46 +72,59 @@ def WriteOutput(
     # make sure settings is a class
     settings_class = get_settings(settings)
 
-    # Parse optional parameters 
-    reflections_to_use = settings_class.output_settings.get("reflections_to_use", Requirements()[1]["reflections_to_use"]) # -- pick which set of reflections to use for unit cell volume
-    phase              = settings_class.output_settings.get("phase", Requirements()[1]["phase"])
-    SampleGeometry     = settings_class.output_settings.get("SampleGeometry", Requirements()[1]["SampleGeometry"])
-    SampleDeformation  = settings_class.output_settings.get("SampleDeformation", Requirements()[1]["SampleDeformation"])
-    includeUnitCells   = settings_class.output_settings.get("includeUnitCells", Requirements()[1]["includeUnitCells"])
-    weighted           = settings_class.output_settings.get("weighted", Requirements()[1]["weighted"])
-    dp                 = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
-    col_width          = settings_class.output_settings.get("col_width", Requirements()[1]["col_width"])
-    ordering_of_output = settings_class.output_settings.get("ordering_of_output", Requirements()[1]["ordering_of_output"])
-    #override with kwargs
+    # Parse optional parameters
+    reflections_to_use = settings_class.output_settings.get(
+        "reflections_to_use", Requirements()[1]["reflections_to_use"]
+    )  # -- pick which set of reflections to use for unit cell volume
+    phase = settings_class.output_settings.get("phase", Requirements()[1]["phase"])
+    SampleGeometry = settings_class.output_settings.get(
+        "SampleGeometry", Requirements()[1]["SampleGeometry"]
+    )
+    SampleDeformation = settings_class.output_settings.get(
+        "SampleDeformation", Requirements()[1]["SampleDeformation"]
+    )
+    includeUnitCells = settings_class.output_settings.get(
+        "includeUnitCells", Requirements()[1]["includeUnitCells"]
+    )
+    weighted = settings_class.output_settings.get(
+        "weighted", Requirements()[1]["weighted"]
+    )
+    dp = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
+    col_width = settings_class.output_settings.get(
+        "col_width", Requirements()[1]["col_width"]
+    )
+    ordering_of_output = settings_class.output_settings.get(
+        "ordering_of_output", Requirements()[1]["ordering_of_output"]
+    )
+    # override with kwargs
     reflections_to_use = kwargs.get("reflections_to_use", reflections_to_use)
-    phase              = kwargs.get("phase", phase)
-    SampleGeometry     = kwargs.get("SampleGeometry", SampleGeometry)
-    SampleDeformation  = kwargs.get("SampleDeformation", SampleDeformation)
-    includeUnitCells   = kwargs.get("includeUnitCells", includeUnitCells)
-    weighted           = kwargs.get("weighted", weighted)
-    dp                 = kwargs.get("dp", dp)
-    col_width          = kwargs.get("col_width", col_width)
+    phase = kwargs.get("phase", phase)
+    SampleGeometry = kwargs.get("SampleGeometry", SampleGeometry)
+    SampleDeformation = kwargs.get("SampleDeformation", SampleDeformation)
+    includeUnitCells = kwargs.get("includeUnitCells", includeUnitCells)
+    weighted = kwargs.get("weighted", weighted)
+    dp = kwargs.get("dp", dp)
+    col_width = kwargs.get("col_width", col_width)
     ordering_of_output = kwargs.get("ordering_of_output", ordering_of_output)
 
     # force all the kwargs that might be needed
-    set_params = {"reflections_to_use": reflections_to_use,
-                "phase": phase,
-                "SampleGeometry": SampleGeometry,
-                "includeUnitCells": includeUnitCells,
-                "weighted": weighted,
-                "pressure": True, # to calculate pressure, and stresses
-                }
+    set_params = {
+        "reflections_to_use": reflections_to_use,
+        "phase": phase,
+        "SampleGeometry": SampleGeometry,
+        "includeUnitCells": includeUnitCells,
+        "weighted": weighted,
+        "pressure": True,  # to calculate pressure, and stresses
+    }
     kwargs.update(set_params)
 
     # get the unit cells, pressure and stresses from settings.
-    df = fits_to_unitcell(settings,
-                **kwargs
-                )
+    df = fits_to_unitcell(settings, **kwargs)
 
     headers = list(df.columns.values)
-    #order the rows
+    # order the rows
     if ordering_of_output:
-        df = df.sort_values(by=ordering_of_output) 
+        df = df.sort_values(by=ordering_of_output)
 
     # make filename for output
     base = settings_class.datafile_basename
@@ -140,7 +153,7 @@ def WriteOutput(
     else:
         add_text = ""
     add_text += "PressureStresses"
-    
+
     out_file = make_outfile_name(
         base,
         directory=settings_class.output_directory,
@@ -153,8 +166,8 @@ def WriteOutput(
     calc_options = {}
     calc_options["Sample Geometry"] = SampleGeometry
     calc_options["Sample Deformation"] = SampleDeformation
-    #remove hkls from data frame -- write as a header instead
-    cols = [col for col in df.columns if 'hkl' in col]
+    # remove hkls from data frame -- write as a header instead
+    cols = [col for col in df.columns if "hkl" in col]
     hkls = {}
     for i in cols:
         hkls[i] = df[i].iloc[0]
@@ -166,14 +179,17 @@ def WriteOutput(
             key = key[0]
         else:
             key = key[0]
-        calc_options["peaks used"] = "{"+"}, {".join(v for v in hkls[key])+"}"
-    file_header = make_header(settings_class,
-                            derived="Pressures and Stresses", 
-                            calc_options=calc_options, 
-                            additional=[    "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",
-                                            "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",
-                                            "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",]
-                            )
-        
+        calc_options["peaks used"] = "{" + "}, {".join(v for v in hkls[key]) + "}"
+    file_header = make_header(
+        settings_class,
+        derived="Pressures and Stresses",
+        calc_options=calc_options,
+        additional=[
+            "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",
+            "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",
+            "# N.B. THE PRESSURES AND STRESSES IN HERE ARE NOT TESTED. AND MIGHT NOT BE CORRECT. \n",
+        ],
+    )
+
     # write file using panda dataframe
     write_csv(out_file, df, headers, file_header, col_width=col_width, dp=dp)

--- a/src/cpf/output_formatters/WriteUnitCells.py
+++ b/src/cpf/output_formatters/WriteUnitCells.py
@@ -4,11 +4,10 @@ import os
 
 import numpy as np
 
-from cpf.settings import get_settings
 from cpf.output_formatters.convert_fit_to_unitcell import fits_to_unitcell
-from cpf.IO_functions import make_outfile_name
-from cpf.output_formatters.output_csv import write_csv, make_header
-
+from cpf.output_formatters.output_csv import make_header, write_csv
+from cpf.settings import get_settings
+from cpf.util.io import make_outfile_name
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.WriteCoefficientTable")
@@ -23,13 +22,13 @@ def Requirements():
     OptionalParams = {
         ##"Output_directory"  # if no direcrtory is specified write to current directory.
         "reflections_to_use": "all",  # -- pick which set of reflections to use for unit cell volume
-        "phase": True, # -- pick whick phase to fit unit cell for.
-        "SampleGeometry": "3d", # -- geometry of the sample for determining the cnetres from. 2D or 3D.
+        "phase": True,  # -- pick whick phase to fit unit cell for.
+        "SampleGeometry": "3d",  # -- geometry of the sample for determining the cnetres from. 2D or 3D.
         "SampleDeformation": "compression",  # changes calculation between 'compression' and 'extension'.
-        "weighted": True, # -- weighted fit or not. True/False
+        "weighted": True,  # -- weighted fit or not. True/False
         "dp": 5,  # how many decimal points to write out
         "col_width": 15,  # default column width for csv file.
-        "ordering_of_output": None # Just leave as read -- otherwise list of dataframe headers to order by
+        "ordering_of_output": None,  # Just leave as read -- otherwise list of dataframe headers to order by
     }
     # OptionalParams = [
     #     ##"Output_directory"  # if no direcrtory is specified write to current directory.
@@ -48,12 +47,12 @@ def WriteOutput(
     **kwargs,
 ):
     """
-    Write unit-cell volumes derived from fitted peak centroids. Writes the values 
-    to table/csv file.     
+    Write unit-cell volumes derived from fitted peak centroids. Writes the values
+    to table/csv file.
 
     Parameters
     ----------
-    settings : cpf.settings.Settings() class 
+    settings : cpf.settings.Settings() class
         input file or settings class used to make the fits.
     *args : TYPE
         DESCRIPTION.
@@ -65,41 +64,53 @@ def WriteOutput(
     # make sure settings is a class
     settings_class = get_settings(settings)
 
-    # Parse optional parameters 
-    reflections_to_use = settings_class.output_settings.get("reflections_to_use", Requirements()[1]["reflections_to_use"]) # -- pick which set of reflections to use for unit cell volume
-    phase              = settings_class.output_settings.get("phase", Requirements()[1]["phase"])
-    SampleGeometry     = settings_class.output_settings.get("SampleGeometry", Requirements()[1]["SampleGeometry"])
-    SampleDeformation = settings_class.output_settings.get("SampleDeformation", Requirements()[1]["SampleDeformation"])
-    weighted           = settings_class.output_settings.get("weighted", Requirements()[1]["weighted"])
-    dp                 = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
-    col_width          = settings_class.output_settings.get("col_width", Requirements()[1]["col_width"])
-    ordering_of_output = settings_class.output_settings.get("ordering_of_output", Requirements()[1]["ordering_of_output"])
-    #override with kwargs
+    # Parse optional parameters
+    reflections_to_use = settings_class.output_settings.get(
+        "reflections_to_use", Requirements()[1]["reflections_to_use"]
+    )  # -- pick which set of reflections to use for unit cell volume
+    phase = settings_class.output_settings.get("phase", Requirements()[1]["phase"])
+    SampleGeometry = settings_class.output_settings.get(
+        "SampleGeometry", Requirements()[1]["SampleGeometry"]
+    )
+    SampleDeformation = settings_class.output_settings.get(
+        "SampleDeformation", Requirements()[1]["SampleDeformation"]
+    )
+    weighted = settings_class.output_settings.get(
+        "weighted", Requirements()[1]["weighted"]
+    )
+    dp = settings_class.output_settings.get("dp", Requirements()[1]["dp"])
+    col_width = settings_class.output_settings.get(
+        "col_width", Requirements()[1]["col_width"]
+    )
+    ordering_of_output = settings_class.output_settings.get(
+        "ordering_of_output", Requirements()[1]["ordering_of_output"]
+    )
+    # override with kwargs
     reflections_to_use = kwargs.get("reflections_to_use", reflections_to_use)
-    phase              = kwargs.get("phase", phase)
-    SampleGeometry     = kwargs.get("SampleGeometry", SampleGeometry)
-    SampleDeformation  = kwargs.get("SampleDeformation", SampleDeformation)
-    weighted           = kwargs.get("weighted", weighted)
-    dp                 = kwargs.get("dp", dp)
-    col_width          = kwargs.get("col_width", col_width)
+    phase = kwargs.get("phase", phase)
+    SampleGeometry = kwargs.get("SampleGeometry", SampleGeometry)
+    SampleDeformation = kwargs.get("SampleDeformation", SampleDeformation)
+    weighted = kwargs.get("weighted", weighted)
+    dp = kwargs.get("dp", dp)
+    col_width = kwargs.get("col_width", col_width)
     ordering_of_output = kwargs.get("ordering_of_output", ordering_of_output)
 
     # force all the kwargs that might be needed
-    set_params = {#"temperature": np.nan,
-                "reflections_to_use": reflections_to_use,
-                "phase": phase,
-                "SampleGeometry": SampleGeometry,
-                "weighted": weighted,
-                "pressure": False, # to supress pressure, and stresses
-                }
+    set_params = {  # "temperature": np.nan,
+        "reflections_to_use": reflections_to_use,
+        "phase": phase,
+        "SampleGeometry": SampleGeometry,
+        "weighted": weighted,
+        "pressure": False,  # to supress pressure, and stresses
+    }
     kwargs.update(set_params)
-    
+
     # get the unit cells from settings.
     df = fits_to_unitcell(settings, **kwargs)
     headers = list(df.columns.values)
-    #order the rows
+    # order the rows
     if ordering_of_output:
-        df = df.sort_values(by=ordering_of_output) 
+        df = df.sort_values(by=ordering_of_output)
 
     # make filename for output
     base = settings_class.datafile_basename
@@ -120,8 +131,8 @@ def WriteOutput(
     calc_options = {}
     calc_options["Sample Geometry"] = SampleGeometry
     calc_options["Sample Deformation"] = SampleDeformation
-    #remove hkls from data frame -- write as a header instead
-    cols = [col for col in df.columns if 'hkl' in col]
+    # remove hkls from data frame -- write as a header instead
+    cols = [col for col in df.columns if "hkl" in col]
     hkls = {}
     for i in cols:
         hkls[i] = df[i].iloc[0]
@@ -133,11 +144,10 @@ def WriteOutput(
             key = key[0]
         else:
             key = key[0]
-        calc_options["peaks used"] = "{"+"} {".join(v for v in hkls[key])+"}"
-    file_header = make_header(settings_class,
-                            derived="Unit Cells", 
-                            calc_options=calc_options
-                            )
+        calc_options["peaks used"] = "{" + "} {".join(v for v in hkls[key]) + "}"
+    file_header = make_header(
+        settings_class, derived="Unit Cells", calc_options=calc_options
+    )
 
     # write file using panda dataframe
     write_csv(out_file, df, headers, file_header, col_width=col_width, dp=dp)

--- a/src/cpf/output_formatters/convert_fit_to_crystallographic.py
+++ b/src/cpf/output_formatters/convert_fit_to_crystallographic.py
@@ -11,7 +11,7 @@ from cpf.output_formatters.crystallographic_operations import plane_indices_4_to
 
 # from uncertainties import ufloat
 from cpf.output_formatters.jcpds import jcpds
-from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
+from cpf.util.io import make_outfile_name, peak_hkl, replace_value
 from cpf.util.logging import get_logger
 
 
@@ -114,7 +114,7 @@ def fourier_to_crystallographic(
         raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # catch 'null' terms in fits
-    coefficients = replace_null_terms(coefficients, replace_with=np.nan)
+    coefficients = replace_value(coefficients, replace_with=np.nan)
 
     # catch d-spacing that is too short for 3D geometry to work.
     if len(coefficients[subpattern]["peak"][peak]["d-space"]) <= 3:
@@ -495,7 +495,7 @@ def fourier_to_unitcellvolume(
         reflections_to_use = list(range(len(flat_coef)))
 
     # catch 'null' terms in fits
-    flat_coef = replace_null_terms(flat_coef, replace_with=np.nan)
+    flat_coef = replace_value(flat_coef, replace_with=np.nan)
 
     # get or guess phase
     if phase is None:

--- a/src/cpf/output_formatters/convert_fit_to_crystallographic.py
+++ b/src/cpf/output_formatters/convert_fit_to_crystallographic.py
@@ -1,20 +1,18 @@
 __all__ = ["fourier_to_crystallographic"]
 
-import json
-import pandas as pd
-import numpy as np
 import glob
+import json
 import re
-# from uncertainties import ufloat
 
-from cpf.output_formatters.jcpds import jcpds
-from cpf.IO_functions import peak_hkl
+import numpy as np
+import pandas as pd
+
 from cpf.output_formatters.crystallographic_operations import plane_indices_4_to_3
-from cpf.IO_functions import replace_null_terms
-from cpf.IO_functions import make_outfile_name
 
+# from uncertainties import ufloat
+from cpf.output_formatters.jcpds import jcpds
+from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
 from cpf.util.logging import get_logger
-
 
 
 def fourier_to_crystallographic(
@@ -62,17 +60,17 @@ def fourier_to_crystallographic(
     Returns
     -------
     differential_coefficients : dict
-        Dictionary of the calculated properties and their errors. The propertues calculated from the 
-        Fourier d-spacing coefficients are: 
+        Dictionary of the calculated properties and their errors. The propertues calculated from the
+        Fourier d-spacing coefficients are:
             "d_mean" -- mean d-spacing of diffraction ring, assuming 2d or 3d 'SampleGeometry'
-            "differential" -- differential 
+            "differential" -- differential
             "Q" -- differential strain
             "orientation" -- orientation of the strain field, under 'SampleDeformation'
             "d_max" -- maximum d-sapcing of fitted diffraction peak
             "d_min" -- minimum d-sapcing of fitted diffraction peak
             "x0" -- cartesian coordinate for centre of diffraction peak
             "y0" -- cartesian coordinate for centre of diffraction peak
-        
+
 
     SampleGeometry options:
         - either 2d or 3d
@@ -116,12 +114,12 @@ def fourier_to_crystallographic(
         raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # catch 'null' terms in fits
-    coefficients = replace_null_terms(coefficients, replace_with = np.nan)
-    
+    coefficients = replace_null_terms(coefficients, replace_with=np.nan)
+
     # catch d-spacing that is too short for 3D geometry to work.
     if len(coefficients[subpattern]["peak"][peak]["d-space"]) <= 3:
         SampleGeometry == "2d"
-    
+
     # %% differential coefficients, errors and covarience
     # %%% angle
     # a = sin??
@@ -135,7 +133,7 @@ def fourier_to_crystallographic(
         out_angerr = 0
     elif (
         len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 4
-        and coefficients[subpattern]["peak"][peak]["d-space"][4] != 0 
+        and coefficients[subpattern]["peak"][peak]["d-space"][4] != 0
         and coefficients[subpattern]["peak"][peak]["d-space"][3] != 0
     ):
         out_ang = (
@@ -170,11 +168,11 @@ def fourier_to_crystallographic(
                     ** 2
                 )
                 ** (1 / 2)
-            ) 
-        / 2
+            )
+            / 2
         )
     elif (
-        len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 5 
+        len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 5
         and coefficients[subpattern]["peak"][peak]["d-space"][3] != 0
     ):
         out_ang = np.pi / 2
@@ -184,7 +182,10 @@ def fourier_to_crystallographic(
         out_angerr = np.nan
         # FIXME: this is a bodged fix for now. It needs to be calcualted assuming the error is not also zero.
     # correction to make angle correct (otherwise potentially out by pi/2)
-    if len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 4 and coefficients[subpattern]["peak"][peak]["d-space"][4] > 0:
+    if (
+        len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 4
+        and coefficients[subpattern]["peak"][peak]["d-space"][4] > 0
+    ):
         if coefficients[subpattern]["peak"][peak]["d-space"][3] <= 0:
             out_ang += np.pi / 2
         else:
@@ -192,12 +193,13 @@ def fourier_to_crystallographic(
     # convert into degrees.
     out_ang = np.rad2deg(out_ang)
     out_angerr = np.rad2deg(out_angerr)
-    
+
     # deal with sin/cos wrapping
-    if (len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 4 and 
-           coefficients[subpattern]["peak"][peak]["d-space"][3] > 0):
+    if (
+        len(coefficients[subpattern]["peak"][peak]["d-space"]) >= 4
+        and coefficients[subpattern]["peak"][peak]["d-space"][3] > 0
+    ):
         out_ang += 180
-    
 
     # %%% differential strain
     # differentail (3d) = (a2^2+b2^2)^(1/2)
@@ -227,8 +229,8 @@ def fourier_to_crystallographic(
     else:
         out_dd = 0
         out_dderr = np.nan
-    
-    #%%% d_max and d_min.
+
+    # %%% d_max and d_min.
     # differential max
     out_dmax = coefficients[subpattern]["peak"][peak]["d-space"][0] + out_dd
     out_dmaxerr = (
@@ -251,7 +253,7 @@ def fourier_to_crystallographic(
             pass
         elif SampleDeformation == "extension":
             pass  # out_ang += 90
-            
+
     elif SampleGeometry == "3d" and SampleDeformation == "compression":
         # 1/3 of the way from the middle to the maximum d-spacing (miniminm strain)
         out_d0 = coefficients[subpattern]["peak"][peak]["d-space"][0] + out_dd / 3
@@ -300,31 +302,29 @@ def fourier_to_crystallographic(
             out_ang -= 90
         else:
             out_ang += 90
-            
 
-    # keep anblies within given range. Prevent wrapping of angles. Change direction of Q and 
-    # differential if the angles are in second half of the range. 
+    # keep anblies within given range. Prevent wrapping of angles. Change direction of Q and
+    # differential if the angles are in second half of the range.
     if True:
         ang_range = [45, -135]
         # if ang_range[0] - ang_range[1] != 180:
         #     raise ValueError("The acceptable range for 'ang_range' is 180 degrees.")
-        if out_ang > ang_range[0]: 
+        if out_ang > ang_range[0]:
             out_ang -= 180
         elif out_ang <= ang_range[1]:
             out_ang += 180
         if out_ang < np.mean(ang_range):
             out_dd = -out_dd
             out_Q = -out_Q
-            
-    
+
     # keep in constant refernce frame -- i.e. strain relative to vertical not absolute.
     if False:
         if out_ang <= -45:
             # out_ang += 90
             out_dd = -out_dd
             out_Q = -out_Q
-   
-        if out_ang >=45:
+
+        if out_ang >= 45:
             out_ang -= 180
 
     """
@@ -333,7 +333,7 @@ def fourier_to_crystallographic(
         out_dd = -out_dd
         out_Q = -out_Q
     # else compression and 'correct'
-    """  
+    """
 
     # %%% x0 and y0
     # values is in d-spacing and needs converting to mm via calibration.
@@ -370,7 +370,7 @@ def fourier_to_crystallographic(
     # FIX ME: this should be removed but remains becuase some outputs depend on it.
     differential_coefficients["dp"] = out_d0
     differential_coefficients["dp_err"] = out_d0err
-    
+
     differential_coefficients["d_mean"] = out_d0
     differential_coefficients["d_mean_err"] = out_d0err
 
@@ -395,28 +395,27 @@ def fourier_to_crystallographic(
     return differential_coefficients
 
 
-
 def fourier_to_unitcellvolume(
     coefficients,
     jcpds_file: None,
     phase: None,
     SampleGeometry: str = "3d",
     SampleDeformation: str = "compression",
-    pressure = False,
-    reflections_to_use = "all",
+    pressure=False,
+    reflections_to_use="all",
     correlation_coeffs=None,
-    weighted = True,
-    temperature = np.nan,
+    weighted=True,
+    temperature=np.nan,
     debug=False,
     **kwargs,
 ):
     """
     Convert fitted peak centers into unit cell parameters.
-    
+
     The method builds a jcpds object and then fits the unit cell to the given peaks.
-    
-    FIXME: no errors are currently used or returned. 
-    
+
+    FIXME: no errors are currently used or returned.
+
     Parameters
     ----------
     coefficients : dict
@@ -437,7 +436,7 @@ def fourier_to_unitcellvolume(
 
     :Keyword Arguments:
         * *reflections_to_use* list  or "all"
-          Which ranges from the list of fitted ranges to use. 
+          Which ranges from the list of fitted ranges to use.
           FIXME: does not work for multiple peaks in the same region
 
     Raises
@@ -449,7 +448,7 @@ def fourier_to_unitcellvolume(
     -------
     unitcell_volumes : dict
         Dictionary of the calculated cell parameters and the errors.
-        
+
 
     SampleGeometry options:
         - either 2d or 3d
@@ -484,15 +483,15 @@ def fourier_to_unitcellvolume(
     if isinstance(coefficients, dict):
         coefficients = [coefficients]
     if not isinstance(coefficients, list):
-        raise ValueError("The coefficients need to be a list of dictionaries.")        
+        raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # flatten the multipeak parts of the coefficient structure.
     flat_coef = []
     for i in coefficients:
         for j in i["peak"]:
-            flat_coef.append({"peak":[j]})
+            flat_coef.append({"peak": [j]})
 
-    if reflections_to_use=="all":
+    if reflections_to_use == "all":
         reflections_to_use = list(range(len(flat_coef)))
 
     # catch 'null' terms in fits
@@ -500,76 +499,87 @@ def fourier_to_unitcellvolume(
 
     # get or guess phase
     if phase is None:
-        #list all phases in fits
+        # list all phases in fits
         phases = []
         for i in range(len(flat_coef)):
             for j in range(len(flat_coef[i]["peak"])):
                 if "phase" in flat_coef[i]["peak"][j]:
                     phases.append(flat_coef[i]["peak"][j]["phase"])
-        phase = max(set(phases), key=phases.count)  
-    
+        phase = max(set(phases), key=phases.count)
+
     # %% get d0 accounting for difrerential strain and sample geometry
     for i in reflections_to_use:
-        crystallographic = fourier_to_crystallographic(flat_coef,
-                        SampleGeometry,
-                        SampleDeformation,
-                        correlation_coeffs,
-                        subpattern=i,
-                        peak=0, # in flattened structure always the first peak
-                        debug=debug,
-                        **kwargs)
+        crystallographic = fourier_to_crystallographic(
+            flat_coef,
+            SampleGeometry,
+            SampleDeformation,
+            correlation_coeffs,
+            subpattern=i,
+            peak=0,  # in flattened structure always the first peak
+            debug=debug,
+            **kwargs,
+        )
         flat_coef[i]["peak"][0]["cryst_prop"] = crystallographic
 
     # intial guess (a0, b0, c0 etc) for lattice parameters comes from jcpds file
-    # solve for unit cell    
+    # solve for unit cell
     jcpds_obj = jcpds()
     jcpds_obj.load_file(jcpds_file)
-    #clear reflections from jcpds
+    # clear reflections from jcpds
     jcpds_obj.remove_reflection("all")
-    
+
     # add reflections for unit cell we need to fit.
     hkls = []
     for i in reflections_to_use:
-        j = 0 # always the first peak in flattened structure.
+        j = 0  # always the first peak in flattened structure.
         # for j in range(len(flat_coef[1]["peak"])):
         if flat_coef[i]["peak"][j]["phase"] == phase:
             hkl = peak_hkl(flat_coef[i], j, string=False)[0]
             if len(hkl) == 4:
                 # convert to 3 value Miller indicies
                 hkl = plane_indices_4_to_3(hkl)
-            jcpds_obj.add_reflection(h=hkl[0], k=hkl[1], l=hkl[2],
-                             dobs = flat_coef[i]["peak"][j]["cryst_prop"]["dp"],
-                             dobs_err = flat_coef[i]["peak"][j]["cryst_prop"]["dp_err"],
-                             delta_dobs = flat_coef[i]["peak"][j]["cryst_prop"]["Q"],
-                             delta_dobs_err = flat_coef[i]["peak"][j]["cryst_prop"]["Q_err"],
-                             orientationobs = flat_coef[i]["peak"][j]["cryst_prop"]["orientation"],
-                             orientationobs_err = flat_coef[i]["peak"][j]["cryst_prop"]["orientation_err"],
-                             )
-            hkls.append( peak_hkl(flat_coef[i], j, string=True)[0] )
-                
-    jcpds_obj.compute_d0() # compute lattice parameters for unit cell from jcpds, otherwise initiation not complete. 
-    
+            jcpds_obj.add_reflection(
+                h=hkl[0],
+                k=hkl[1],
+                l=hkl[2],
+                dobs=flat_coef[i]["peak"][j]["cryst_prop"]["dp"],
+                dobs_err=flat_coef[i]["peak"][j]["cryst_prop"]["dp_err"],
+                delta_dobs=flat_coef[i]["peak"][j]["cryst_prop"]["Q"],
+                delta_dobs_err=flat_coef[i]["peak"][j]["cryst_prop"]["Q_err"],
+                orientationobs=flat_coef[i]["peak"][j]["cryst_prop"]["orientation"],
+                orientationobs_err=flat_coef[i]["peak"][j]["cryst_prop"][
+                    "orientation_err"
+                ],
+            )
+            hkls.append(peak_hkl(flat_coef[i], j, string=True)[0])
+
+    jcpds_obj.compute_d0()  # compute lattice parameters for unit cell from jcpds, otherwise initiation not complete.
+
     jcpds_obj.temperature = temperature
-    
+
     returned = jcpds_obj.fit_lattice_parameters(weighted=weighted)
 
     uc_parts = jcpds_obj.get_unique_unitcell_params()
     uc_parms = {}
-    
-    #force observed value first in order
-    if not np.isnan(temperature) and pressure: 
+
+    # force observed value first in order
+    if not np.isnan(temperature) and pressure:
         uc_parms["temperature"] = jcpds_obj.temperature
-    
+
     for ind in range(len(uc_parts)):
         uc_parms[uc_parts[ind]] = getattr(jcpds_obj, uc_parts[ind]).nominal_value
-        uc_parms[uc_parts[ind]+"_err"] = getattr(jcpds_obj, uc_parts[ind]).std_dev
+        uc_parms[uc_parts[ind] + "_err"] = getattr(jcpds_obj, uc_parts[ind]).std_dev
     uc_parms["volume"] = jcpds_obj.v.nominal_value
     uc_parms["volume_err"] = jcpds_obj.v.std_dev
-    
-    if not np.isnan(temperature) and pressure: 
+
+    if not np.isnan(temperature) and pressure:
         uc_parms["pressure"] = jcpds_obj.pressure.nominal_value
         uc_parms["pressure_err"] = jcpds_obj.pressure.std_dev
-        for m,n,o in zip(jcpds_obj.get_reflection_stresses(), jcpds_obj.get_reflection_orientations(), jcpds_obj.get_reflection_hkls()):
+        for m, n, o in zip(
+            jcpds_obj.get_reflection_stresses(),
+            jcpds_obj.get_reflection_orientations(),
+            jcpds_obj.get_reflection_hkls(),
+        ):
             o = f"({o[0]}{o[1]}{o[2]})"
             uc_parms[o + " stress"] = m.nominal_value
             uc_parms[o + " stress_err"] = m.std_dev

--- a/src/cpf/output_formatters/convert_fit_to_crystallographic.py
+++ b/src/cpf/output_formatters/convert_fit_to_crystallographic.py
@@ -114,7 +114,7 @@ def fourier_to_crystallographic(
         raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # catch 'null' terms in fits
-    coefficients = replace_value(coefficients, replace_with=np.nan)
+    coefficients = replace_value(coefficients, old=None, new=np.nan)
 
     # catch d-spacing that is too short for 3D geometry to work.
     if len(coefficients[subpattern]["peak"][peak]["d-space"]) <= 3:
@@ -495,7 +495,7 @@ def fourier_to_unitcellvolume(
         reflections_to_use = list(range(len(flat_coef)))
 
     # catch 'null' terms in fits
-    flat_coef = replace_value(flat_coef, replace_with=np.nan)
+    flat_coef = replace_value(flat_coef, old=None, new=np.nan)
 
     # get or guess phase
     if phase is None:

--- a/src/cpf/output_formatters/convert_fit_to_crystallographic.py
+++ b/src/cpf/output_formatters/convert_fit_to_crystallographic.py
@@ -534,7 +534,7 @@ def fourier_to_unitcellvolume(
         j = 0  # always the first peak in flattened structure.
         # for j in range(len(flat_coef[1]["peak"])):
         if flat_coef[i]["peak"][j]["phase"] == phase:
-            hkl = peak_hkl(flat_coef[i], j, string=False)[0]
+            hkl = peak_hkl(flat_coef[i], j, as_string=False)[0]
             if len(hkl) == 4:
                 # convert to 3 value Miller indicies
                 hkl = plane_indices_4_to_3(hkl)
@@ -551,7 +551,7 @@ def fourier_to_unitcellvolume(
                     "orientation_err"
                 ],
             )
-            hkls.append(peak_hkl(flat_coef[i], j, string=True)[0])
+            hkls.append(peak_hkl(flat_coef[i], j, as_string=True)[0])
 
     jcpds_obj.compute_d0()  # compute lattice parameters for unit cell from jcpds, otherwise initiation not complete.
 

--- a/src/cpf/output_formatters/convert_fit_to_unitcell.py
+++ b/src/cpf/output_formatters/convert_fit_to_unitcell.py
@@ -1,45 +1,40 @@
 __all__ = ["fits_to_unitcell"]
 
-import json
-import pandas as pd
-import numpy as np
 import glob
+import json
 import re
-# from uncertainties import ufloat
 
+import numpy as np
+import pandas as pd
+
+from cpf.output_formatters.convert_fit_to_crystallographic import (
+    fourier_to_crystallographic,
+    fourier_to_unitcellvolume,
+)
+from cpf.output_formatters.fits_io import ReadFits_to_dataframe, ReadFits_to_list
+
+# from uncertainties import ufloat
 from cpf.output_formatters.jcpds import jcpds
 from cpf.settings import get_settings
-from cpf.IO_functions import peak_hkl
-from cpf.output_formatters.fits_io import ReadFits_to_dataframe, ReadFits_to_list
-from cpf.IO_functions import replace_null_terms
-from cpf.IO_functions import make_outfile_name
-from cpf.output_formatters.convert_fit_to_crystallographic import fourier_to_crystallographic, fourier_to_unitcellvolume
-from cpf.util.logging import get_logger
-
-
+from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.convert_fit_to_unitcell")
 
 
-def fits_to_unitcell(
-        settings,
-        *args,
-        **kwargs
-        ):
-    
+def fits_to_unitcell(settings, *args, **kwargs):
     """
-    Processes all fits and returns dataframe of unit parameters calculated from 
-    values in fit (json) files. 
+    Processes all fits and returns dataframe of unit parameters calculated from
+    values in fit (json) files.
 
     Parameters
     ----------
     settings : cpf.Settings.settings() Class, str (filename), Path
         Class containing all the fitting parameters.
     *args
-    
+
     **kwargs
-    
+
     Raises
     ------
     ValueError
@@ -51,47 +46,49 @@ def fits_to_unitcell(
         Data frame contiaing all the fits made when calling the settings_class/file.
 
     """
-    
+
     # make sure settings is a class
     settings_class = get_settings(settings)
-        
+
     # settings_class.output_settings["phase"]
-    
-    # Parse required parameters 
-    SampleGeometry    = settings_class.output_settings.get("SampleGeometry", "3d")
-    SampleDeformation = settings_class.output_settings.get("SampleDeformation", "compression")
+
+    # Parse required parameters
+    SampleGeometry = settings_class.output_settings.get("SampleGeometry", "3d")
+    SampleDeformation = settings_class.output_settings.get(
+        "SampleDeformation", "compression"
+    )
     phase = settings_class.output_settings.get("phase", True)
     jcpds_file = settings_class.output_settings.get("jcpds", None)
-    #override with kwargs
+    # override with kwargs
     SampleGeometry = kwargs.get("SampleGeometry", SampleGeometry)
     SampleDeformation = kwargs.get("SampleDeformation", SampleDeformation)
     phase = kwargs.get("phase", phase)
     jcpds_file = kwargs.get("jcpds", jcpds_file)
-    
+
     # set the kwargs as needed.
     kwargs["includeSeriesValues"] = kwargs.get("includeSeriesValues", True)
     kwargs["includePosition"] = kwargs.get("includePosition", True)
-    
+
     pressure = kwargs.get("pressure", False)
     kwargs["pressure"] = pressure
-    
+
     # kwargs["phase"] = phase
     # kwargs["jcpds"] = jcpds_file
-    
+
     # get the fits
     all_fits, all_metadata = ReadFits_to_list(settings=settings_class)
-    
+
     # read all the data.
     all_cells = []
-    
+
     for z in range(settings_class.image_number):
         settings_class.set_subpattern(z, 0)
-    
+
         # if settings_class.file_label:
         #     additional_text = settings_class.file_label
         # else:
         #     additional_text = None
-    
+
         # filename = make_outfile_name(
         #     settings_class.subfit_filename,  # diff_files[z],
         #     directory=settings_class.output_directory,  # directory=FitSettings.Output_directory,
@@ -99,14 +96,14 @@ def fits_to_unitcell(
         #     additional_text=additional_text,
         #     overwrite=True,
         # )  # overwrite =false to get the file name without incrlemeting it.
-    
+
         # Read JSON data from file
         # with open(filename) as json_data:
         #     fits = json.load(json_data)
-            
+
         fits = all_fits[z]
         metadata = all_metadata[z]
-            
+
         # get converted values.
         for i in range(len(fits)):
             for j in range(len(fits[i]["peak"])):
@@ -118,7 +115,7 @@ def fits_to_unitcell(
                     peak=j,
                 )
                 fits[i]["peak"][j]["crystallographic_values"] = crystallographic_values
-                
+
         # stash names for output
         cells_tmp = {}
         cells_tmp["num"] = z
@@ -131,23 +128,23 @@ def fits_to_unitcell(
         # add metadata
         for i in settings_class.metadata:
             cells_tmp[i] = metadata[i]
-                    
+
         # get or guess phase
         if not isinstance(phase, str):
-            #list all phases in fits
+            # list all phases in fits
             phases = []
             for i in range(len(fits)):
                 for j in range(len(fits[i]["peak"])):
                     if "phase" in fits[i]["peak"][j]:
                         phases.append(fits[i]["peak"][j]["phase"])
             phase = np.unique(phases)
-            
+
         if isinstance(phase, str):
             phase = [phase]
-                        
+
             # if "phase" in settings_class.output_settings:
             #     phase = settings_class.output_settings["phase"]
-                
+
             # else:
             #     #list all phases in fits
             #     phases = []
@@ -156,9 +153,9 @@ def fits_to_unitcell(
             #             if "phase" in fits[i]["peak"][j]:
             #                 phases.append(fits[i]["peak"][j]["phase"])
             #     phase = np.unique(phases)
-            
+
         # get or guess jcpds file
-        
+
         if not isinstance(phase, str):
             jcpds_file = []
             for i in range(len(phase)):
@@ -174,8 +171,7 @@ def fits_to_unitcell(
                 raise ValueError("There is no jcpds or cif file recognised")
             elif len(phase) != len(jcpds_file):
                 raise ValueError("The phase and jcpds files do not match")
-        
-        
+
         # if "jcpds" in settings_class.output_settings:
         #     jcpds = settings_class.output_settings["jcpds"]
         # else:
@@ -193,21 +189,29 @@ def fits_to_unitcell(
         #         raise ValueError("There is no jcpds or cif file recognised")
         #     elif len(phase) != len(jcpds):
         #         raise ValueError("The phase and jcpds files do not match")
-                
-        #get temperature from metadata
+
+        # get temperature from metadata
         # get label for temperature. Should work for wild cards
         if "temperature" in settings_class.metadata_labels:
-            templbl_without_wildcards = re.sub(r"\*", ".*", settings_class.metadata_labels["temperature"])
+            templbl_without_wildcards = re.sub(
+                r"\*", ".*", settings_class.metadata_labels["temperature"]
+            )
         elif "temperature" in settings_class.data_class._default_metadata_labels:
-            templbl_without_wildcards = re.sub(r"\*", ".*", settings_class.data_class._default_metadata_labels["temperature"])
+            templbl_without_wildcards = re.sub(
+                r"\*",
+                ".*",
+                settings_class.data_class._default_metadata_labels["temperature"],
+            )
         else:
             templbl_without_wildcards = "None"
         r = re.compile(templbl_without_wildcards)
-        templbl = list(filter(r.match, list(metadata))) # Read Note below
+        templbl = list(filter(r.match, list(metadata)))  # Read Note below
         if len(templbl) == 1:
             templbl = templbl[0]
         elif len(templbl) > 1:
-            err_str = "More than one temprature has been found. Assuming the first one. "
+            err_str = (
+                "More than one temprature has been found. Assuming the first one. "
+            )
             logger.error(err_str)
             templbl = templbl[0]
         elif templbl == []:
@@ -220,33 +224,33 @@ def fits_to_unitcell(
             temp = 0
 
         # calculate unit cell properties and return them
-        for i in range (len(phase)):
-            
+        for i in range(len(phase)):
             kwargs_here = kwargs
-            
-            kwargs_here.pop("phase",None)
-            kwargs_here.pop("jcpds",None)
+
+            kwargs_here.pop("phase", None)
+            kwargs_here.pop("jcpds", None)
             unitcells = fourier_to_unitcellvolume(
                 fits,
                 # SampleGeometry=SampleGeometry,
                 # SampleDeformation=SampleDeformation,
-                phase = phase[i],
-                jcpds_file = jcpds_file[i],
-                temperature = temp,
-                **kwargs_here
+                phase=phase[i],
+                jcpds_file=jcpds_file[i],
+                temperature=temp,
+                **kwargs_here,
             )
-            
-            # label return with phase name and add to fits                    
+
+            # label return with phase name and add to fits
             entries = list(unitcells)
             for j in range(len(unitcells)):
-                unitcells[re.sub(entries[j], phase[i]+" "+entries[j], entries[j])] = unitcells.pop(entries[j])
-                
+                unitcells[
+                    re.sub(entries[j], phase[i] + " " + entries[j], entries[j])
+                ] = unitcells.pop(entries[j])
+
             cells_tmp.update(unitcells)
-                
+
         all_cells.append(cells_tmp)
-            
+
     # make data frame using headers - so columns are in sensible order.
     df = pd.DataFrame(all_cells)
-    
+
     return df
-              

--- a/src/cpf/output_formatters/convert_fit_to_unitcell.py
+++ b/src/cpf/output_formatters/convert_fit_to_unitcell.py
@@ -16,7 +16,7 @@ from cpf.output_formatters.fits_io import ReadFits_to_dataframe, ReadFits_to_lis
 # from uncertainties import ufloat
 from cpf.output_formatters.jcpds import jcpds
 from cpf.settings import get_settings
-from cpf.util.io import make_outfile_name, peak_hkl, replace_null_terms
+from cpf.util.io import make_outfile_name, peak_hkl, replace_value
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.convert_fit_to_unitcell")

--- a/src/cpf/output_formatters/fits_io.py
+++ b/src/cpf/output_formatters/fits_io.py
@@ -191,7 +191,7 @@ def ReadFits_to_list(settings, replace=True, *args, **kwargs):
     if replace:
         # keep the null terms if we want/need.
         # used for keeting errors in the previous fits
-        fits = replace_value(fits, val_to_find=None, replace_with=0)
+        fits = replace_value(fits, old=None, new=0)
     return fits, metadata
 
 

--- a/src/cpf/output_formatters/fits_io.py
+++ b/src/cpf/output_formatters/fits_io.py
@@ -5,33 +5,43 @@ __all__ = ["WriteFits", "ReadFits_to_list", "ReadFits_to_dataframe", "read_metad
 
 
 import json
-from itertools import product
+import os
 import re
-# import glob
+from itertools import product
 
+# import glob
 import numpy as np
 import pandas as pd
-import os
 
 import cpf.peak_functions as pf
-from cpf.settings import get_settings
-from cpf.output_formatters.convert_fit_to_crystallographic import fourier_to_crystallographic
-from cpf.IO_functions import make_outfile_name, peak_phase, peak_hkl, json_numpy_serializer, replace_null_terms
+from cpf.output_formatters.convert_fit_to_crystallographic import (
+    fourier_to_crystallographic,
+)
 from cpf.series_functions import series_properties
+from cpf.settings import get_settings
+from cpf.util.io import (
+    json_numpy_serializer,
+    make_outfile_name,
+    peak_hkl,
+    peak_phase,
+    replace_null_terms,
+)
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.output_formatters.fits_io")
 
 
-def WriteFits(settings_class, fitted_param, filename_to_write=None, data_class=None, mode=None):
+def WriteFits(
+    settings_class, fitted_param, filename_to_write=None, data_class=None, mode=None
+):
     """
-    Write fits and any metadata to json files. 
+    Write fits and any metadata to json files.
 
     Writees the files as:
     {"fits"":      [list of fits for each range in settings_class.fit_orders],
      "metadata": {dict of metadata properties as named in settings class .... }
      }
-    
+
     Parameters
     ----------
     settings_class : cpf settings class
@@ -45,7 +55,7 @@ def WriteFits(settings_class, fitted_param, filename_to_write=None, data_class=N
         Data class that contains the image metadata. The default is None.
     mode : string, optional
         Switch to add string to file name (if not spedified). The default is None.
-    
+
     Returns
     -------
     None.
@@ -60,14 +70,13 @@ def WriteFits(settings_class, fitted_param, filename_to_write=None, data_class=N
         else:
             out = fitted_param
         for i in out:
-            i.pop("correlation_coeffs",None)
+            i.pop("correlation_coeffs", None)
     elif data_class:
         metadata = data_class.get_metadata(settings_class=settings_class)
-        out = {"metadata": metadata,
-               "fits": fitted_param}
+        out = {"metadata": metadata, "fits": fitted_param}
     else:
         out = {"fits": fitted_param}
-    
+
     if filename_to_write is None:
         if mode == "search":
             additional_text = settings_class.file_label
@@ -80,7 +89,7 @@ def WriteFits(settings_class, fitted_param, filename_to_write=None, data_class=N
             extension=".json",
             overwrite=True,
         )
-    
+
     with open(filename_to_write, "w") as TempFile:
         # Write a JSON string into the file.
         json.dump(
@@ -90,23 +99,17 @@ def WriteFits(settings_class, fitted_param, filename_to_write=None, data_class=N
             indent=2,
             default=json_numpy_serializer,
         )
-        
 
 
-def ReadFits_to_list(
-    settings,
-    replace=True,
-    *args,
-    **kwargs
-):
+def ReadFits_to_list(settings, replace=True, *args, **kwargs):
     """
-    Read coefficents from json fits files and return values as list. 
+    Read coefficents from json fits files and return values as list.
 
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
 
     Raises
@@ -122,44 +125,43 @@ def ReadFits_to_list(
         List contiaing metadata for each file in settings_class/file.
 
     """
-    
+
     if isinstance(settings, str) and "PreviousFit" in settings:
-        #read previous fit
+        # read previous fit
         with open(settings) as json_data:
-                json_contents = json.load(json_data)
+            json_contents = json.load(json_data)
         if "fits" in json_contents:
             fits = json_contents["fits"]
         else:
             fits = json_contents
         metadata = None
     else:
-        
         # make sure settings is a class
         settings_class = get_settings(settings)
-    
+
         # read all the data.
         fits = []
         metadata = []
         for z in range(settings_class.image_number):
             settings_class.set_subpattern(z, 0)
-    
+
             if settings_class.file_label:
                 additional_text = settings_class.file_label
             else:
                 additional_text = None
             filename = make_outfile_name(
-                settings_class.subfit_filename,  
+                settings_class.subfit_filename,
                 directory=settings_class.output_directory,
                 extension=".json",
                 additional_text=additional_text,
                 overwrite=True,
             )
-    
+
             # Read JSON data from file
             with open(filename) as json_data:
                 json_contents = json.load(json_data)
                 if isinstance(json_contents, dict):
-                    #new style as dictionary with metadata
+                    # new style as dictionary with metadata
                     fits.append(json_contents["fits"])
                     metadata.append(json_contents["metadata"])
                 else:
@@ -170,57 +172,55 @@ def ReadFits_to_list(
                     fnam = settings_class.subfit_filename[0]
                 else:
                     fnam = settings_class.subfit_filename
-                if (os.path.isfile(fnam) and
-                    sorted(settings_class.metadata) != sorted(list(metadata[-1]))):
-                        # then we need to read the metadata from the files
-                        metadata[-1] = read_metadata(settings_class)
-            
+                if os.path.isfile(fnam) and sorted(settings_class.metadata) != sorted(
+                    list(metadata[-1])
+                ):
+                    # then we need to read the metadata from the files
+                    metadata[-1] = read_metadata(settings_class)
+
             # convert correlation coefficients into panda data frame
             for y in range(len(fits[-1])):
                 if "correlation_coeffs" in fits[-1][y]:
                     try:
                         fits[-1][y]["correlation_coeffs"] = pd.DataFrame.from_dict(
-                                               json.loads(fits[-1][y]["correlation_coeffs"])
-                                               )
+                            json.loads(fits[-1][y]["correlation_coeffs"])
+                        )
                     except:
                         pass
-    
-    if replace: 
+
+    if replace:
         # keep the null terms if we want/need.
         # used for keeting errors in the previous fits
-        fits = replace_null_terms(
-            fits, val_to_find=None, replace_with=0
-        )
+        fits = replace_null_terms(fits, val_to_find=None, replace_with=0)
     return fits, metadata
-
 
 
 def ReadFits_to_dataframe(
     settings,
-    includeParameters = "all",
+    includeParameters="all",
     includeStats=False,
-    includeSeriesValues = False,
-    includeIntensityRanges = False,
-    includeUnitCells = False,
-    includePosition = False,
+    includeSeriesValues=False,
+    includeIntensityRanges=False,
+    includeUnitCells=False,
+    includePosition=False,
     *args,
-    **kwargs
+    **kwargs,
 ):
     """
-    Read coefficents from json fits files and return values as panda dataframe. 
+    Read coefficents from json fits files and return values as panda dataframe.
 
     Parameters
     ----------
     settings : [str | Path | dict | Settings()]
-        Class containing all variables and options needed for the fitting, or 
-        dictionary of all the settings or 
+        Class containing all variables and options needed for the fitting, or
+        dictionary of all the settings or
         string or path to a file with the settings in.
     includeParameters : list[str], optional
         List of which peak parameters to return. The default is "all".
     includeStats : bool, optional
         Switch to include all fitting statistics in output data frame. The default is False.
     includeSeriesValues : bool or list, optional
-        Switch to include values derived from the fit parameters. Either a list of parameters returned by  
+        Switch to include values derived from the fit parameters. Either a list of parameters returned by
         cpf.output_formatters.convert_fit_to_crystallographic or a bool. The default is False.
 
     Raises
@@ -249,32 +249,42 @@ def ReadFits_to_dataframe(
         includeParameters = peak_properties[1]
 
     if includeSeriesValues is not False or includeUnitCells is not False:
-        # Parse needed parameters 
-        SampleGeometry     = settings_class.output_settings.get("SampleGeometry", "3d")
-        SampleDeformation  = settings_class.output_settings.get("SampleDeformation", "compression")
-        #override with kwargs
-        SampleGeometry     = kwargs.get("SampleGeometry", SampleGeometry)
-        SampleDeformation  = kwargs.get("SampleDeformation", SampleDeformation)
+        # Parse needed parameters
+        SampleGeometry = settings_class.output_settings.get("SampleGeometry", "3d")
+        SampleDeformation = settings_class.output_settings.get(
+            "SampleDeformation", "compression"
+        )
+        # override with kwargs
+        SampleGeometry = kwargs.get("SampleGeometry", SampleGeometry)
+        SampleDeformation = kwargs.get("SampleDeformation", SampleDeformation)
         # force all the kwargs that might be needed
-        set_params = {"SampleGeometry": SampleGeometry,
-                    "SampleDeformation": SampleDeformation,
-                    }
+        set_params = {
+            "SampleGeometry": SampleGeometry,
+            "SampleDeformation": SampleDeformation,
+        }
         kwargs.update(set_params)
-    
-    if includeIntensityRanges is not False: 
+
+    if includeIntensityRanges is not False:
         # get the intensity maximum and minimum of the fit, model and residuals
-        IntensityValues = ["data_max", "data_min", "model_max", "model_min", "residual_max", "residual_min"]
+        IntensityValues = [
+            "data_max",
+            "data_min",
+            "model_max",
+            "model_min",
+            "residual_max",
+            "residual_min",
+        ]
     else:
         IntensityValues = []
-        
+
     # read all the data.
     fits, metadata = ReadFits_to_list(settings_class, args, kwargs)
-    
+
     num_fits = 0
     max_peaks = 0
     for z in range(settings_class.image_number):
         settings_class.set_subpattern(z, 0)
-        
+
         if includeSeriesValues is not False:
             # get converted values.
             for i in range(len(fits[z])):
@@ -286,8 +296,10 @@ def ReadFits_to_dataframe(
                         subpattern=i,
                         peak=j,
                     )
-                    fits[z][i]["peak"][j]["crystallographic_values"] = crystallographic_values
-                    
+                    fits[z][i]["peak"][j]["crystallographic_values"] = (
+                        crystallographic_values
+                    )
+
                     # it not continuous_azm then need to know where the detectors are
                     if settings_class.data_class.continuous_azm == False:
                         data_class = settings_class.data_class
@@ -297,28 +309,43 @@ def ReadFits_to_dataframe(
                         )
                         azms = np.unique(data_class.azm)
                     else:
-                        azms = 0.01 # default spacing 
-                    
-                    height_properties = series_properties(fits[z], subpattern = i, peak=j, param="height", azm_spacing=azms)
-                    width_properties = series_properties(fits[z], subpattern = i, peak=j, param="width", azm_spacing=azms)
-                    profile_properties = series_properties(fits[z], subpattern = i, peak=j, param="profile", azm_spacing=azms)
-                    
-                    fits[z][i]["peak"][j]["crystallographic_values"] = fits[z][i]["peak"][j]["crystallographic_values"] | height_properties
-                    fits[z][i]["peak"][j]["crystallographic_values"] = fits[z][i]["peak"][j]["crystallographic_values"] | width_properties
-                    fits[z][i]["peak"][j]["crystallographic_values"] = fits[z][i]["peak"][j]["crystallographic_values"] | profile_properties
-        
+                        azms = 0.01  # default spacing
+
+                    height_properties = series_properties(
+                        fits[z], subpattern=i, peak=j, param="height", azm_spacing=azms
+                    )
+                    width_properties = series_properties(
+                        fits[z], subpattern=i, peak=j, param="width", azm_spacing=azms
+                    )
+                    profile_properties = series_properties(
+                        fits[z], subpattern=i, peak=j, param="profile", azm_spacing=azms
+                    )
+
+                    fits[z][i]["peak"][j]["crystallographic_values"] = (
+                        fits[z][i]["peak"][j]["crystallographic_values"]
+                        | height_properties
+                    )
+                    fits[z][i]["peak"][j]["crystallographic_values"] = (
+                        fits[z][i]["peak"][j]["crystallographic_values"]
+                        | width_properties
+                    )
+                    fits[z][i]["peak"][j]["crystallographic_values"] = (
+                        fits[z][i]["peak"][j]["crystallographic_values"]
+                        | profile_properties
+                    )
+
         if includeSeriesValues is not False:
-            #list the entries in crystallographic_values dictionary
+            # list the entries in crystallographic_values dictionary
             DerivedValues = fits[z][0]["peak"][0]["crystallographic_values"].keys()
         else:
             DerivedValues = []
         num_fits = np.max([num_fits, len(fits[z])])
         for y in range(len(fits[z])):
             max_peaks = np.max([max_peaks, len(fits[z][y]["peak"])])
-    
+
     # get number of coefficients.
     # get the coefficients from the json file rather than the setting/input file
-    # because the number of fits might not the same as in the settings file, 
+    # because the number of fits might not the same as in the settings file,
     # for example, afer running cpf.XRD_FitPatter.order_search()
     max_coef = {}
     for w in range(len(includeParameters)):
@@ -338,8 +365,10 @@ def ReadFits_to_dataframe(
                     if y >= len(max_coef[ind]):
                         max_coef[ind].append(len(fits[0][x][ind][y]))
                     else:
-                        max_coef[ind][y] = np.max([max_coef[ind][y], len(fits[0][x][ind][y])])
-            else: #peak related parameter
+                        max_coef[ind][y] = np.max(
+                            [max_coef[ind][y], len(fits[0][x][ind][y])]
+                        )
+            else:  # peak related parameter
                 # iterate over the number of peaks
                 for y in range(len(fits[0][x]["peak"])):
                     if ind not in fits[0][x]["peak"][y]:
@@ -348,8 +377,10 @@ def ReadFits_to_dataframe(
                     elif isinstance(fits[0][x]["peak"][y][ind], int):
                         max_coef[ind] = np.max([max_coef[ind], 1])
                     else:
-                        max_coef[ind] = np.max([max_coef[ind], len(fits[0][x]["peak"][y][ind])])
-    
+                        max_coef[ind] = np.max(
+                            [max_coef[ind], len(fits[0][x]["peak"][y][ind])]
+                        )
+
     # make list of headers for panda data frame
     headers = []
     headers.append("num")
@@ -362,8 +393,7 @@ def ReadFits_to_dataframe(
             headers.append(i)
     headers.append("range_start")
     headers.append("range_end")
-    
-    
+
     # parmeter header list
     for w in range(len(max_coef)):
         ind = includeParameters[w]
@@ -375,7 +405,7 @@ def ReadFits_to_dataframe(
                 for v in range(max_coef[ind][u]):
                     headers.append(ind + str(u) + "_" + str(v))
                     headers.append(ind + str(u) + "_" + str(v) + "_err")
-        else: # ind is a peak parameter
+        else:  # ind is a peak parameter
             headers.append(ind + "_type")
             for v in range(max_coef[ind]):
                 headers.append(ind + str(v))
@@ -394,7 +424,7 @@ def ReadFits_to_dataframe(
         properties += IntensityValues
     if includeStats is True:
         # include properties from the lmfit output that were passed with the fits.
-        #read the list of parameters from the first file.
+        # read the list of parameters from the first file.
         if "FitProperties" in fits[0][0]:
             properties += list(fits[0][0]["FitProperties"])
     if "note" in fits[0][0]:
@@ -404,11 +434,11 @@ def ReadFits_to_dataframe(
         # which always adds notes to the json fit files.
         properties.append("pos_in_range")
     headers += properties
-    
+
     # make lists of the parameters to iterate over
     # then sort them in to order by peak
     images = list(range(settings_class.image_number))
-    subpatterns = list(range(num_fits))#list(range(num_subpatterns))
+    subpatterns = list(range(num_fits))  # list(range(num_subpatterns))
     max_peaks = 1
     for i in range(len(settings_class.fit_orders)):
         max_peaks = np.max([max_peaks, len(settings_class.fit_orders[i]["peak"])])
@@ -417,14 +447,14 @@ def ReadFits_to_dataframe(
     # sort lists by peaks
     lists = lists[np.lexsort((lists[:, 2],))]
     lists = lists[np.lexsort((lists[:, 1],))]
-        
+
     # write the data to array, then append to dataframe
     RowsList = []
     for z in range(len(lists)):
-        settings_class.set_subpattern(lists[z,0], 0)
+        settings_class.set_subpattern(lists[z, 0], 0)
         RowLst = {}
         data_to_write = fits[lists[z, 0]][lists[z, 1]]
-        
+
         if len(data_to_write["peak"]) > lists[z, 2]:
             RowLst["num"] = lists[z, 0]
             if isinstance(settings_class.subfit_filename, list):
@@ -432,27 +462,32 @@ def ReadFits_to_dataframe(
                 RowLst["DataFile"] = os.path.split(settings_class.subfit_filename[0])[1]
             else:
                 RowLst["DataFile"] = os.path.split(settings_class.subfit_filename)[1]
-            
+
             # RowLst["Peak"] = peak_string(fits[lists[z, 0]][lists[z, 1]], peak=[lists[z, 2]], fname=False)
-            RowLst["phase"] = peak_phase(fits[lists[z, 0]][lists[z, 1]], peak=[lists[z, 2]])[0]
-            RowLst["peak"] = peak_hkl(fits[lists[z, 0]][lists[z, 1]], peak=[lists[z, 2]])[0]
+            RowLst["phase"] = peak_phase(
+                fits[lists[z, 0]][lists[z, 1]], peak=[lists[z, 2]]
+            )[0]
+            RowLst["peak"] = peak_hkl(
+                fits[lists[z, 0]][lists[z, 1]], peak=[lists[z, 2]]
+            )[0]
             RowLst["range_start"] = data_to_write["range"][0][0]
             RowLst["range_end"] = data_to_write["range"][0][1]
 
             for w in settings_class.metadata:
                 if "/" in w:
-                    #cut to last part of h5key
-                    RowLst[w] = metadata[lists[z,0]][w.split("/")[-1]]
+                    # cut to last part of h5key
+                    RowLst[w] = metadata[lists[z, 0]][w.split("/")[-1]]
                 else:
-                    RowLst[w] = metadata[lists[z,0]][w]
-                
+                    RowLst[w] = metadata[lists[z, 0]][w]
+
             for w in range(len(includeParameters)):
                 ind = includeParameters[w]
                 ind_err = ind + "_err"
 
                 if ind != "background" and ind != "symmetry":
-                    
-                    RowLst[ind+"_type"] =  data_to_write["peak"][lists[z, 2]][ind+"_type"]
+                    RowLst[ind + "_type"] = data_to_write["peak"][lists[z, 2]][
+                        ind + "_type"
+                    ]
                     for v in range(len(data_to_write["peak"][lists[z, 2]][ind])):
                         if (
                             data_to_write["peak"][lists[z, 2]][ind][v] is None
@@ -481,9 +516,9 @@ def ReadFits_to_dataframe(
                         RowLst[ind] = data_to_write["peak"][lists[z, 2]][ind]
                     except:
                         pass
-                    
+
                 else:  # background
-                    RowLst[ind+"_type"] =  data_to_write[ind+"_type"]
+                    RowLst[ind + "_type"] = data_to_write[ind + "_type"]
                     for u in range(len(data_to_write[ind])):
                         for v in range(len(data_to_write[ind][u])):
                             if (
@@ -503,7 +538,7 @@ def ReadFits_to_dataframe(
                                 )
                             except:
                                 RowLst[ind + str(u) + "_" + str(v) + "_err"] = "None"
-                                
+
             for w in range(len(properties)):
                 ind = properties[w]
 
@@ -513,13 +548,15 @@ def ReadFits_to_dataframe(
                         RowLst[ind] = fits[lists[z, 0]][lists[z, 1]]["note"]
 
                 elif ind == "pos_in_range":
-                    RowLst[ind] = lists[z, 2]          
-                
+                    RowLst[ind] = lists[z, 2]
+
                 elif ind in DerivedValues:
                     # in crystallographic_values dictionary
-                    RowLst[ind] = data_to_write["peak"][lists[z, 2]]["crystallographic_values"][ind]
+                    RowLst[ind] = data_to_write["peak"][lists[z, 2]][
+                        "crystallographic_values"
+                    ][ind]
                     # RowLst[ind+"err"] = data_to_write["peak"][lists[z, 2]]["crystallographic_values"][ind+"_err"]
-                
+
                 elif ind == "Position in json":
                     # print("here we are ")
                     # print(lists[z, 1])
@@ -529,7 +566,7 @@ def ReadFits_to_dataframe(
                     if ind == "data_max":
                         RowLst[ind] = data_to_write["DataProperties"]["max"]
                     elif ind == "data_min":
-                        RowLst[ind] = data_to_write["DataProperties"]["min"]                    
+                        RowLst[ind] = data_to_write["DataProperties"]["min"]
                     elif ind == "model_max":
                         RowLst[ind] = data_to_write["ModelProperties"]["max"]
                     elif ind == "model_min":
@@ -542,12 +579,14 @@ def ReadFits_to_dataframe(
                         raise ValueError("Unknown value to read")
 
                 else:
-                    if (data_to_write["FitProperties"][ind] is None):  
+                    if data_to_write["FitProperties"][ind] is None:
                         # catch 'null' as an error
                         data_to_write["FitProperties"][ind] = np.nan
                     if isinstance(data_to_write["FitProperties"][ind], str):
                         # make sure that status, or another string, does not have commass.
-                        RowLst[ind] = re.sub(', ', ';', str(data_to_write["FitProperties"][ind]))
+                        RowLst[ind] = re.sub(
+                            ", ", ";", str(data_to_write["FitProperties"][ind])
+                        )
                     else:
                         RowLst[ind] = data_to_write["FitProperties"][ind]
 
@@ -562,11 +601,11 @@ def ReadFits_to_dataframe(
 def read_metadata(settings_class):
     """
     Reads the metadata for the image specified in settings_class.subfit_filename.
-    
+
     Parameters
     ----------
     settings_class : cpf settings class
-        Settings clsss in which settings_class.subfit_filename is set to the file 
+        Settings clsss in which settings_class.subfit_filename is set to the file
         to be read.
 
     Returns
@@ -578,20 +617,22 @@ def read_metadata(settings_class):
         fnam = settings_class.subfit_filename[0]
     else:
         fnam = settings_class.subfit_filename
-        
+
     if settings_class.subfit_filename == None:
         raise ValueError("no file is specified")
     if not os.path.isfile(fnam):
-        raise FileExistsError("The file {os.path.split(fnam)[1]} does not exist on the path")
-    
-    #get data from settings class
+        raise FileExistsError(
+            "The file {os.path.split(fnam)[1]} does not exist on the path"
+        )
+
+    # get data from settings class
     new_data = settings_class.data_class
-    
+
     new_data.fill_data(
         settings_class.subfit_filename,
         settings=settings_class,
     )
-    
+
     new_data.import_image(settings=settings_class)
     metadata = new_data.get_metadata(metadata_values=settings_class.metadata)
     return metadata

--- a/src/cpf/output_formatters/fits_io.py
+++ b/src/cpf/output_formatters/fits_io.py
@@ -24,7 +24,7 @@ from cpf.util.io import (
     numpy_to_json,
     peak_hkl,
     peak_phase,
-    replace_null_terms,
+    replace_value,
 )
 from cpf.util.logging import get_logger
 
@@ -191,7 +191,7 @@ def ReadFits_to_list(settings, replace=True, *args, **kwargs):
     if replace:
         # keep the null terms if we want/need.
         # used for keeting errors in the previous fits
-        fits = replace_null_terms(fits, val_to_find=None, replace_with=0)
+        fits = replace_value(fits, val_to_find=None, replace_with=0)
     return fits, metadata
 
 

--- a/src/cpf/output_formatters/fits_io.py
+++ b/src/cpf/output_formatters/fits_io.py
@@ -20,8 +20,8 @@ from cpf.output_formatters.convert_fit_to_crystallographic import (
 from cpf.series_functions import series_properties
 from cpf.settings import get_settings
 from cpf.util.io import (
-    json_numpy_serializer,
     make_outfile_name,
+    numpy_to_json,
     peak_hkl,
     peak_phase,
     replace_null_terms,
@@ -97,7 +97,7 @@ def WriteFits(
             TempFile,
             sort_keys=True,
             indent=2,
-            default=json_numpy_serializer,
+            default=numpy_to_json,
         )
 
 

--- a/src/cpf/series_functions.py
+++ b/src/cpf/series_functions.py
@@ -21,25 +21,25 @@ __all__ = [
     "background_expansion",
 ]
 
+import re
+
 import numpy as np
 import numpy.ma as ma
-import re
 from scipy.interpolate import CubicSpline, make_interp_spline
 
 import cpf.peak_functions as pf
 import cpf.series_constraints as sc
-from cpf.IO_functions import replace_null_terms
+from cpf.util.io import replace_null_terms
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.series_functions")
-
 
 
 def coefficient_types(full=False):
     """
     Defines the coefficient types possible and the numbers associated with them.
 
-    The series types and their associated numbers are: 
+    The series types and their associated numbers are:
          0: 'fourier'
          1: 'spline_linear', 'linear'
          2: 'spline_quadratic', 'quadratic'
@@ -48,13 +48,13 @@ def coefficient_types(full=False):
          5: 'spline_quadratic_open', 'quadratic_open'
          6: 'spline_cubic_open', 'cubic_open', 'spline_open'
          7: 'independent'
-    When cycled through the code the first value in each of these options is the one that 
+    When cycled through the code the first value in each of these options is the one that
     will be added to the json files. So 'linear' will be written as 'spline_linear'
 
     Parameters
     ----------
     full : bool, optional
-        Return dirctionary with just series numbers (False) or with all ancillary 
+        Return dirctionary with just series numbers (False) or with all ancillary
         information for fitting (True). The default is False.
 
     Returns
@@ -65,79 +65,113 @@ def coefficient_types(full=False):
     """
     coeff_types = {}
     # add fourier series type
-    coeff_types = {"fourier": {"num": 0,  "expansion_function": "fourier_expand" },}   
+    coeff_types = {
+        "fourier": {"num": 0, "expansion_function": "fourier_expand"},
+    }
     # add spline, linear, periodic series type
-    coeff_types |= {"spline_linear": {
+    coeff_types |= {
+        "spline_linear": {
             "num": 1,
             "expansion_function": "spline_expand",
             "boundary_conditions": "periodic",
             "spline_type": "linear",
-            },}
-    coeff_types |= {"linear": coeff_types["spline_linear"],}
+        },
+    }
+    coeff_types |= {
+        "linear": coeff_types["spline_linear"],
+    }
     # add spline, quadratic, periodic series type
-    coeff_types |= {"spline_quadratic": {
+    coeff_types |= {
+        "spline_quadratic": {
             "num": 2,
             "expansion_function": "spline_expand",
             "boundary_conditions": "periodic",
             "spline_type": "quadratic",
-            },}
-    coeff_types |= {"quadratic": coeff_types["spline_quadratic"],}
-    # add spline, cubic, periodic series type    
-    coeff_types |= {"spline_cubic": {
+        },
+    }
+    coeff_types |= {
+        "quadratic": coeff_types["spline_quadratic"],
+    }
+    # add spline, cubic, periodic series type
+    coeff_types |= {
+        "spline_cubic": {
             "num": 3,
             "expansion_function": "spline_expand",
             "boundary_conditions": "periodic",
             "spline_type": "cubic",
-            },}
-    coeff_types |= {"cubic": coeff_types["spline_cubic"],}
-    coeff_types |= {"spline": coeff_types["spline_cubic"],}
-    coeff_types |= {"spline-cubic": coeff_types["spline_cubic"],}
-    
-    # add spline, linear, open series type    
-    coeff_types |= {"spline_linear_open": {
+        },
+    }
+    coeff_types |= {
+        "cubic": coeff_types["spline_cubic"],
+    }
+    coeff_types |= {
+        "spline": coeff_types["spline_cubic"],
+    }
+    coeff_types |= {
+        "spline-cubic": coeff_types["spline_cubic"],
+    }
+
+    # add spline, linear, open series type
+    coeff_types |= {
+        "spline_linear_open": {
             "num": 4,
             "expansion_function": "spline_expand",
             "boundary_conditions": "natural",
             "spline_type": "linear",
-            },}
-    coeff_types |= {"linear_open": coeff_types["spline_linear_open"],}
-    # add spline, quardartic, open series type    
-    coeff_types |= {"spline_quadratic_open": {
+        },
+    }
+    coeff_types |= {
+        "linear_open": coeff_types["spline_linear_open"],
+    }
+    # add spline, quardartic, open series type
+    coeff_types |= {
+        "spline_quadratic_open": {
             "num": 5,
             "expansion_function": "spline_expand",
             "boundary_conditions": "natural",
             "spline_type": "quadratic",
-            },}
-    coeff_types |= {"quadratic_open": coeff_types["spline_quadratic_open"],}
-    # add spline, cubic, open series type    
-    coeff_types |= {"spline_cubic_open": {
+        },
+    }
+    coeff_types |= {
+        "quadratic_open": coeff_types["spline_quadratic_open"],
+    }
+    # add spline, cubic, open series type
+    coeff_types |= {
+        "spline_cubic_open": {
             "num": 6,
             "expansion_function": "spline_expand",
             "boundary_conditions": "natural",
             "spline_type": "cubic",
-            },}
-    coeff_types |= {"cubic_open": coeff_types["spline_cubic_open"],}
-    coeff_types |= {"spline_open": coeff_types["spline_cubic_open"],}    
-    
-    # add independent coefficients. 
-    coeff_types |= {"independent": {
+        },
+    }
+    coeff_types |= {
+        "cubic_open": coeff_types["spline_cubic_open"],
+    }
+    coeff_types |= {
+        "spline_open": coeff_types["spline_cubic_open"],
+    }
+
+    # add independent coefficients.
+    coeff_types |= {
+        "independent": {
             "num": 7,
             "expansion_function": "spline_expand",
             "boundary_conditions": "natural",
             "spline_type": "independent",
-            },}
-        
-    if full!=True:
+        },
+    }
+
+    if full != True:
         for i in range(len(coeff_types)):
             ky = list(coeff_types.keys())[i]
             coeff_types[ky] = coeff_types[ky]["num"]
-    
+
     return coeff_types
 
 
 def coefficient_type_as_number(series_type, return_error=1):
     """
-    Returns serise type as a number from given string. 
+    Returns serise type as a number from given string.
     The key,value pairs are defined in series_functions.coefficient_types()
 
     Parameters
@@ -145,7 +179,7 @@ def coefficient_type_as_number(series_type, return_error=1):
     series_type : str
         series type name string.
     return_error : bool, optional
-        return an error string, rather than raising an error. 
+        return an error string, rather than raising an error.
 
     Raises
     ------
@@ -162,27 +196,28 @@ def coefficient_type_as_number(series_type, return_error=1):
     if series_type in types.keys():
         out = types[series_type]
     elif series_type in types.values():
-        #if input is a recognised number then return a number. 
+        # if input is a recognised number then return a number.
         out = series_type
     else:
-        error_str = ("Unrecognised string index for series type. The valid options are "
+        error_str = (
+            "Unrecognised string index for series type. The valid options are "
             "defined in cpf.series_functions.coefficient_types()"
-            )
+        )
         if return_error == 0:
             raise ValueError(error_str)
         else:
             out = error_str
     return out
-    
+
 
 def coefficient_type_as_string(series_type):
     """
-    Returns series type as a string from given number. 
+    Returns series type as a string from given number.
     The key,value pairs are defined in series_functions.coefficient_types()
 
     Parameters
     ----------
-    series_type : float, int, 
+    series_type : float, int,
         series type name string.
 
     Raises
@@ -198,7 +233,7 @@ def coefficient_type_as_string(series_type):
     """
     types = coefficient_types()
     if series_type in list(types.keys()):
-        #if input is a recognised strong then return a strong.
+        # if input is a recognised strong then return a strong.
         out = series_type
     elif series_type in list(types.values()):
         out = list(types.keys())[list(types.values()).index(series_type)]
@@ -246,7 +281,7 @@ def get_series_type(param, param_str, comp=None):
 def get_params_type(orders, comp, peak=0):
     """
     Get series type from input orders.
-    
+
     Parameters
     ----------
     orders : dict
@@ -276,12 +311,12 @@ def get_params_type(orders, comp, peak=0):
 def get_number_coeff(orders, comp, peak=0, azimuths=None):
     """
     Returns the expected number of coefficients from order value
-    
+
     For a fourier series the number of coefficients is 2n+1.
-    The same convention is adopted for spline series. 
-    For 'independent' series, the number of unique azimuths is needed to determine 
-    the number of coefficients. 
-    
+    The same convention is adopted for spline series.
+    For 'independent' series, the number of unique azimuths is needed to determine
+    the number of coefficients.
+
     Parameters
     ----------
     orders : dict
@@ -330,18 +365,18 @@ def get_number_coeff(orders, comp, peak=0, azimuths=None):
 def get_order_from_coeff(n_coeff, parm_num=0, azimuths=None):
     """
     Returns the order of a series from the number of coefficients it contains
-    
+
     For a fourier series the order is (n-1)/2.
-    The same convention is adopted for spline series. 
-    For 'independent' series, the number of unique azimuths is needed to determine 
-    the number of coefficients. 
-    
+    The same convention is adopted for spline series.
+    For 'independent' series, the number of unique azimuths is needed to determine
+    the number of coefficients.
+
     Parameters
     ----------
     n_coeff : num
         Number of cofficents in the series.
     parm_num : int or str, optional
-        Label for series type - either a string or a numeric value, as defined in 
+        Label for series type - either a string or a numeric value, as defined in
         series_functions.coefficient_types(). The default is 0.
     azimuths : np.array, optional
         array of unique azimuths. The default is None.
@@ -375,7 +410,7 @@ def get_order_from_params(params, comp=None, peak=0):
     Calculate the order of the series from a list of coefficients
 
     The order of the series is: (len(coefficients)-1) / 2
-    
+
     Parameters
     ----------
     params : list
@@ -394,7 +429,7 @@ def get_order_from_params(params, comp=None, peak=0):
     -------
     order : int
         Order fo the series.
-        
+
     """
     # Given list of Fourier coefficients return order (n)
     if isinstance(params, (list,)):
@@ -416,7 +451,7 @@ def get_order_from_params(params, comp=None, peak=0):
         logger.critical(" ".join(map(str, [(err_str)])))
         raise ValueError(err_str)
 
-    #convert from lenth to an order.
+    # convert from lenth to an order.
     order = get_order_from_coeff(l)
 
     return order
@@ -424,7 +459,7 @@ def get_order_from_params(params, comp=None, peak=0):
 
 def get_series_mean(param, param_str, comp=None):
     """
-    Calcualte the mean of the parameter series from lmfit parameter dictionary or 
+    Calcualte the mean of the parameter series from lmfit parameter dictionary or
     settings coefficient dictionary.
 
     Parameters
@@ -446,18 +481,21 @@ def get_series_mean(param, param_str, comp=None):
     # We should use the medaian and the mean deviation from the median...
     if param_str in param:
         # then this is not a lmfit parameter dictionary but a coefficient dictionary.
-        if param_str+"_type" in param:# 
-            series_type = param[param_str+"_type"]
+        if param_str + "_type" in param:  #
+            series_type = param[param_str + "_type"]
         else:
-            series_type = 'fourier'
-        if series_type == 'fourier':
+            series_type = "fourier"
+        if series_type == "fourier":
             mean = param[param_str][0]
         else:
             # get a mean of all the coefficients
             mean = np.nanmean(param[param_str])
-    
+
     else:
-        if get_series_type(param, param_str, comp=comp) == coefficient_types()["fourier"]:
+        if (
+            get_series_type(param, param_str, comp=comp)
+            == coefficient_types()["fourier"]
+        ):
             # if it is a Fourier series just get the first value.
             mean = param[param_str + "_" + comp + "0"].value
         else:
@@ -486,7 +524,7 @@ def coefficient_expand(
     **params,
 ):
     """
-    Calcuate the value of a series at each azimuth. 
+    Calcuate the value of a series at each azimuth.
 
     Parameters
     ----------
@@ -516,12 +554,12 @@ def coefficient_expand(
     """
     series_name = coefficient_type_as_string(coeff_type)
     all_series = coefficient_types(full=True)
-    
+
     # FIXME: this could be changed so that all_series[series_name]["expansion_function"]
-    # is used with getattr -- allowing easier future expansion of the series types. 
+    # is used with getattr -- allowing easier future expansion of the series types.
     if all_series[series_name]["expansion_function"] == "fourier_expand":
         out = fourier_expand(azimuth, inp_param=param, comp_str=comp_str, **params)
-        
+
     elif all_series[series_name]["expansion_function"] == "spline_expand":
         out = spline_expand(
             azimuth,
@@ -532,13 +570,13 @@ def coefficient_expand(
             kind=all_series[series_name]["spline_type"],
             **params,
         )
-    
+
     else:
         raise ValueError(
             "Unrecognised number index for series type. The valid options are "
             "defined in cpf.series_functions.coefficient_types()"
         )
-        
+
     return out
 
 
@@ -565,7 +603,7 @@ def spline_expand(
     start_end : list, optional
         Minimum and maximum azimuth. The default is [0, 360].
     bc_type : str, optional
-        Bounding conditions type: Options are "indepeddnt", "periodic", and "natural". 
+        Bounding conditions type: Options are "indepeddnt", "periodic", and "natural".
         The default is "periodic".
     kind : str, optional
         Type of spline or independent series. The default is "cubic".
@@ -595,7 +633,7 @@ def spline_expand(
         inp_param = []
         for j in range(len(str_keys)):
             inp_param.append(params[comp_str + str(j)])
-    
+
     if kind == "independent":
         points = np.unique(azimuth)
     elif bc_type == "periodic":
@@ -612,7 +650,7 @@ def spline_expand(
         k = 2
     elif kind == "linear" or kind == "independent":
         k = 1
-        bc_type = None # catch error feeding into make_interp_spline
+        bc_type = None  # catch error feeding into make_interp_spline
     else:
         raise ValueError("Unknown spline type.")
 
@@ -636,10 +674,10 @@ def spline_expand(
         # else:
         if k >= len(points):
             # catch if the spline is underconstrained
-            k = len(points)-1
+            k = len(points) - 1
             if k < 0:
-                k=0
-        spl = make_interp_spline(points, inp_param, k=k, bc_type=bc_type )
+                k = 0
+        spl = make_interp_spline(points, inp_param, k=k, bc_type=bc_type)
 
         fout = spl(azimuth)
 
@@ -720,7 +758,7 @@ def fourier_expand(
 
 def background_expansion(azimuth_two_theta, orders, params):
     """
-    Calculate background value at each azimuth / two theta pair for given series 
+    Calculate background value at each azimuth / two theta pair for given series
     coefficients.
 
     Parameters
@@ -770,19 +808,20 @@ def background_expansion(azimuth_two_theta, orders, params):
         bg_all = bg_all + (out * (two_theta_prime ** float(i)))
     return bg_all
 
+
 def series_properties(
     coefficients,
     correlation_coeffs=None,
     subpattern=0,
     peak=0,
-    param = "height",
-    azm_spacing = 0.01, # 
+    param="height",
+    azm_spacing=0.01,  #
     debug=False,
     **kwargs,
 ):
     """
-    Calcualte series properties from the coefficients. 
-    
+    Calcualte series properties from the coefficients.
+
     Parameters
     ----------
     coefficients : dict
@@ -797,7 +836,7 @@ def series_properties(
         Peak profile parameter to calculate properties for
     azm_spacing : float or list or np.array, optional
         either:
-            Precision to calulate the properties for (if required). 
+            Precision to calulate the properties for (if required).
         or:
             list of azimuths to calculate the properties at
     **kwargs : TYPE
@@ -811,8 +850,8 @@ def series_properties(
     Returns
     -------
     differential_coefficients : dict
-        Dictionary of the calculated properties and their errors. The propertues calculated from the 
-        series coefficients are: 
+        Dictionary of the calculated properties and their errors. The propertues calculated from the
+        series coefficients are:
             "series_mean" -- mean d-spacing of diffraction ring, assuming 2d or 3d 'SampleGeometry'
             "series_max" -- maximum values of series
             "orientation max" -- maximum values of series
@@ -827,21 +866,24 @@ def series_properties(
 
     if not isinstance(coefficients, list):
         raise ValueError("The coefficients need to be a list of dictionaries.")
-            
+
     # catch 'null' terms in fits
     coefficients = replace_null_terms(coefficients, replace_with=np.nan)
 
     properties = {}
 
-
     # height mean
-    if coefficients[subpattern]["peak"][peak][param+"_type"] == "fourier":
+    if coefficients[subpattern]["peak"][peak][param + "_type"] == "fourier":
         properties["series mean"] = coefficients[subpattern]["peak"][peak][param][0]
-        properties["series mean err"] = coefficients[subpattern]["peak"][peak][param+"_err"][0]
+        properties["series mean err"] = coefficients[subpattern]["peak"][peak][
+            param + "_err"
+        ][0]
     else:
         tot = np.sum(coefficients[subpattern]["peak"][peak][param])
         errsum = np.sqrt(
-            np.sum(np.array(coefficients[subpattern]["peak"][peak][param+"_err"]) ** 2)
+            np.sum(
+                np.array(coefficients[subpattern]["peak"][peak][param + "_err"]) ** 2
+            )
         )
         num = len(coefficients[subpattern]["peak"][peak][param])
         properties["series mean"] = tot / num
@@ -856,13 +898,15 @@ def series_properties(
         # then need to use uniquie azimuths that were fed in
         orientations = ma.unique(azm_spacing).compressed()
     else:
-        n = 360/azm_spacing + 1
+        n = 360 / azm_spacing + 1
         orientations = np.linspace(0, 360, int(n))
 
-    vals = coefficient_expand(orientations, 
-                              param=coefficients[subpattern]["peak"][peak][param], 
-                              coeff_type=coefficients[subpattern]["peak"][peak][param+"_type"],
-                              comp_str=param)
+    vals = coefficient_expand(
+        orientations,
+        param=coefficients[subpattern]["peak"][peak][param],
+        coeff_type=coefficients[subpattern]["peak"][peak][param + "_type"],
+        comp_str=param,
+    )
     maximum = np.argmax(vals)
     minimum = np.argmin(vals)
     properties["series max"] = vals[maximum]

--- a/src/cpf/series_functions.py
+++ b/src/cpf/series_functions.py
@@ -868,7 +868,7 @@ def series_properties(
         raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # catch 'null' terms in fits
-    coefficients = replace_value(coefficients, replace_with=np.nan)
+    coefficients = replace_value(coefficients, old=None, new=np.nan)
 
     properties = {}
 

--- a/src/cpf/series_functions.py
+++ b/src/cpf/series_functions.py
@@ -29,7 +29,7 @@ from scipy.interpolate import CubicSpline, make_interp_spline
 
 import cpf.peak_functions as pf
 import cpf.series_constraints as sc
-from cpf.util.io import replace_null_terms
+from cpf.util.io import replace_value
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.series_functions")
@@ -868,7 +868,7 @@ def series_properties(
         raise ValueError("The coefficients need to be a list of dictionaries.")
 
     # catch 'null' terms in fits
-    coefficients = replace_null_terms(coefficients, replace_with=np.nan)
+    coefficients = replace_value(coefficients, replace_with=np.nan)
 
     properties = {}
 

--- a/src/cpf/settings.py
+++ b/src/cpf/settings.py
@@ -26,7 +26,7 @@ from cpf.series_functions import (
     coefficient_types,
     get_number_coeff,
 )
-from cpf.util.io import image_list, json_numpy_serializer, make_outfile_name
+from cpf.util.io import image_list, make_outfile_name, numpy_to_json
 
 # , get_output_options, detector_factory, register_default_formats
 from cpf.util.logging import get_logger

--- a/src/cpf/settings.py
+++ b/src/cpf/settings.py
@@ -5,32 +5,28 @@ from __future__ import annotations
 
 __all__ = ["settings", "get_output_options", "detector_factory"]
 
+import glob
 import importlib.util
 import json
-import glob
+import os
+import re
 from copy import copy, deepcopy
 from pathlib import Path
 from typing import Any, Literal, Optional
-import os
-import re
-import numpy as np
 
+import numpy as np
 import proglog
+
 import cpf.input_types as input_types
 import cpf.output_formatters as output_formatters
-from cpf.IO_functions import (
-    image_list,
-    json_numpy_serializer,
-    make_outfile_name
-)
+from cpf.peak_functions import peak_components
 from cpf.series_functions import (
     coefficient_type_as_number,
     coefficient_type_as_string,
     coefficient_types,
     get_number_coeff,
 )
-from cpf.peak_functions import peak_components
-
+from cpf.util.io import image_list, json_numpy_serializer, make_outfile_name
 
 # , get_output_options, detector_factory, register_default_formats
 from cpf.util.logging import get_logger
@@ -41,6 +37,7 @@ from cpf.util.logging import get_logger
 logger = get_logger("cpf.settings")
 
 # from cpf.XRD_FitPattern import logger
+
 
 class Settings:
     """
@@ -79,7 +76,7 @@ class Settings:
         ] = "INFO",
         debug: bool = False,
         mode: Literal["fit"] = "fit",
-        **kwargs
+        **kwargs,
     ):
         """
         Initialise the cpf settings class.
@@ -154,8 +151,8 @@ class Settings:
         self.fit_track: bool = False
         self.fit_propagate: bool = True
 
-        self.metadata = []#None
-        self.metadata_labels = {}#None
+        self.metadata = []  # None
+        self.metadata_labels = {}  # None
         self.metadata_read = None
 
         self.cascade_bin_type: Optional[int] = (
@@ -210,7 +207,6 @@ class Settings:
         new.subfit_orders = deepcopy(self.subfit_orders)
         return new
 
-
     def duplicate_without_dataclass(self):
         """
         Makes a copy of an settings instance but without the data class.
@@ -223,10 +219,9 @@ class Settings:
         """
         new = self.duplicate()
         # remove data_class to allow parallel processing
-        delattr(new, 'data_class')
-        delattr(new, '_unmodified_self')
+        delattr(new, "data_class")
+        delattr(new, "_unmodified_self")
         return new
-
 
     def _validation_copy(self):
         """
@@ -256,25 +251,24 @@ class Settings:
         # remove data_class to allow parallel processing
         copy.pop("data_class", None)
         # remove any possible previous unmodified previous variable.
-        copy.pop('_unmodified_self', None)
+        copy.pop("_unmodified_self", None)
         # remove following from check becuase these can be changed without invalidating the settings class.
-        copy.pop('subfit_file_position', None)
-        copy.pop('subfit_filename', None)
-        copy.pop('subfit_order_position', None)
-        copy.pop('subfit_orders', None)
-        copy.pop('output_types', None)
+        copy.pop("subfit_file_position", None)
+        copy.pop("subfit_filename", None)
+        copy.pop("subfit_order_position", None)
+        copy.pop("subfit_orders", None)
+        copy.pop("output_types", None)
 
         return copy
-
 
     def populate(
         self,
         settings: Optional[str | Path | dict] = None,
-        validate = True,
+        validate=True,
         out_type=None,
         report=False,
         debug=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Fills the settings class from the settings file.
@@ -296,9 +290,13 @@ class Settings:
         """
         # Fail gracefully
         if settings is None:
-            raise ValueError("The settings needs to be specified: it is either a file string, a file path or a dictionary.")
+            raise ValueError(
+                "The settings needs to be specified: it is either a file string, a file path or a dictionary."
+            )
         elif isinstance(settings, type(Settings())):
-            logger.info("The settings are already a cpf Settings class instance. No initiation.")
+            logger.info(
+                "The settings are already a cpf Settings class instance. No initiation."
+            )
             return
 
         elif isinstance(settings, dict):
@@ -316,11 +314,12 @@ class Settings:
                         if isinstance(value, dict):
                             value = RecursiveObject(value)
                         setattr(self, key, value)
-            self.settings_from_input = settings#RecursiveObject(dictionary = settings)
 
+            self.settings_from_input = (
+                settings  # RecursiveObject(dictionary = settings)
+            )
 
         else:
-
             # Convert to a Path object
             if isinstance(settings, str):
                 try:
@@ -337,10 +336,12 @@ class Settings:
 
             # store all the settings from file in a module class.
             module_name = self.settings_file.stem
-            spec = importlib.util.spec_from_file_location(module_name, self.settings_file)
+            spec = importlib.util.spec_from_file_location(
+                module_name, self.settings_file
+            )
             self.settings_from_input = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(self.settings_from_input)
-            #convert to a dictionary
+            # convert to a dictionary
             self.settings_from_input = self.settings_from_input.__dict__
             self.settings_from_input["run_name"] = str(settings)
 
@@ -356,8 +357,7 @@ class Settings:
         """
         self.populate()
 
-
-    def fill_settings(self, validate = True):
+    def fill_settings(self, validate=True):
         """
         adds values to the class from the settings file.
         Fails with a list of missing parameters if not complete.
@@ -428,19 +428,18 @@ class Settings:
             logger.warning(
                 "'Image_prepare' is depreciated nomenclature. Has been replased by 'image_preprocess'"
             )
-            self.settings_from_input["image_preprocess"] = (
-                self.settings_from_input["Image_prepare"]
-            )
+            self.settings_from_input["image_preprocess"] = self.settings_from_input[
+                "Image_prepare"
+            ]
 
         if "image_preprocess" in list(self.settings_from_input):
             self.datafile_preprocess = self.settings_from_input["Image_prepare"]
-
 
         # add data directory and data files
         self.datafile_directory = self.settings_from_input["datafile_directory"]
         if isinstance(self.datafile_directory, str):  # Convert to Path object
             self.datafile_directory = Path(self.datafile_directory)
-        self.check_directory_exists(self.datafile_directory, make_dir = False)
+        self.check_directory_exists(self.datafile_directory, make_dir=False)
 
         (
             self.datafile_list,
@@ -463,19 +462,21 @@ class Settings:
         # If the file type is h5/nxs and there is no h5 related settings in the input then read defaults from the detector class.
         # These settings are then used by the detector class.
         # When the h5 settings are in the settings class we need to re-initiate the image list.
-        if (len(self.datafile_list) == 1
-                and (self.datafile_list[0].suffix == ".h5"
-                or self.datafile_list[0].suffix == ".nxs")):
-            #both "h5_datakey" and "h5_iterate" are required for the h5 file reading to work
+        if len(self.datafile_list) == 1 and (
+            self.datafile_list[0].suffix == ".h5"
+            or self.datafile_list[0].suffix == ".nxs"
+        ):
+            # both "h5_datakey" and "h5_iterate" are required for the h5 file reading to work
             if "h5_datakey" not in list(self.settings_from_input):
-
                 # need to load a data class so we know what the h5 defaults are
                 temp_settings = Settings()
                 temp_settings.calibration_type = self.settings_from_input["Calib_type"]
                 temp_data_class = detector_factory(settings_class=temp_settings)
 
                 if "_default_h5_datakey" in dir(temp_data_class):
-                    self.settings_from_input["h5_datakey"] = temp_data_class._default_h5_datakey
+                    self.settings_from_input["h5_datakey"] = (
+                        temp_data_class._default_h5_datakey
+                    )
                 else:
                     err_str = "The data class has no value for '_default_h5_datakey'. Need to define 'h5_datakey' in settings."
                     logger.warning(err_str)
@@ -483,14 +484,15 @@ class Settings:
             self.h5_datakey = self.settings_from_input["h5_datakey"]
 
             if "h5_iterate" not in list(self.settings_from_input):
-
                 # need to load a data class so we know what the h5 defaults are
                 temp_settings = Settings()
                 temp_settings.calibration_type = self.settings_from_input["Calib_type"]
                 temp_data_class = detector_factory(settings_class=temp_settings)
 
                 if "_default_h5_iterate" in dir(temp_data_class):
-                    self.settings_from_input["h5_iterate"] = temp_data_class._default_h5_iterate
+                    self.settings_from_input["h5_iterate"] = (
+                        temp_data_class._default_h5_iterate
+                    )
                 else:
                     err_str = "The data class has no value for '_default_h5_iterate'. Need to define 'h5_iterate' in settings."
                     logger.warning(err_str)
@@ -506,7 +508,9 @@ class Settings:
             if len(self.datafile_list) > 0:
                 try:
                     self.datafile_list = [
-                        Path(file) for file in self.datafile_list if isinstance(file, str)
+                        Path(file)
+                        for file in self.datafile_list
+                        if isinstance(file, str)
                     ]
                 except Exception as error:
                     raise error
@@ -521,13 +525,13 @@ class Settings:
         if "cascade_bin_type" in list(self.settings_from_input):
             self.cascade_bin_type = self.settings_from_input["cascade_bin_type"]
         if "cascade_historgram_type" in list(self.settings_from_input):
-            self.cascade_historgram_type = (
-                self.settings_from_input["cascade_historgram_type"]
-            )
+            self.cascade_historgram_type = self.settings_from_input[
+                "cascade_historgram_type"
+            ]
         if "cascade_historgram_bins" in list(self.settings_from_input):
-            self.cascade_historgram_bins = (
-                self.settings_from_input["cascade_historgram_bins"]
-            )
+            self.cascade_historgram_bins = self.settings_from_input[
+                "cascade_historgram_bins"
+            ]
 
         # organise the fits
         if "fit_orders" in list(self.settings_from_input):
@@ -539,9 +543,13 @@ class Settings:
         if "fit_propagate" in list(self.settings_from_input):
             self.fit_propagate = self.settings_from_input["fit_propagate"]
         if "fit_min_data_intensity" in list(self.settings_from_input):
-            self.fit_min_data_intensity = self.settings_from_input["fit_min_data_intensity"]
+            self.fit_min_data_intensity = self.settings_from_input[
+                "fit_min_data_intensity"
+            ]
         if "fit_min_peak_intensity" in list(self.settings_from_input):
-            self.fit_min_peak_intensity = self.settings_from_input["fit_min_peak_intensity"]
+            self.fit_min_peak_intensity = self.settings_from_input[
+                "fit_min_peak_intensity"
+            ]
 
         if "AziDataPerBin" in list(self.settings_from_input):
             self.fit_per_bin = self.settings_from_input["AziDataPerBin"]
@@ -554,15 +562,14 @@ class Settings:
 
         # load the data class.
         self.data_class = detector_factory(settings_class=self)
-        
-        #set metadata after data class so can get metadata defaults from it
+
+        # set metadata after data class so can get metadata defaults from it
         self.set_output_types()
         self.set_metadata()
-        
+
         if validate == True:
             self.validate_settings_file()
             # FIXME: it needs to fail if everything is not present as needed and report what is missing
-
 
     def validate_settings_file(self):
         """
@@ -605,12 +612,11 @@ class Settings:
         if self.output_types:
             self.validate_output_types()
 
-        #if it gets to here the settings file has passed all the tests.
+        # if it gets to here the settings file has passed all the tests.
         self._unmodified_self = self._validation_copy()
 
         logger.info("End of Validation")
         logger.info("-----------------------------------------------------------------")
-
 
     def is_valid(self):
         """
@@ -633,10 +639,7 @@ class Settings:
         else:
             return False
 
-    def check_files_exist(
-        self,
-        files_to_check: list[Path] | Path
-    ):
+    def check_files_exist(self, files_to_check: list[Path] | Path):
         """
         Check if a file exists. If not issue an error
         """
@@ -652,14 +655,18 @@ class Settings:
         if len(files_to_check) == 0:
             logger.warning("There are no data files in the settings.")
         else:
-            progress = proglog.default_bar_logger("bar")  # shorthand to generate a bar logger
+            progress = proglog.default_bar_logger(
+                "bar"
+            )  # shorthand to generate a bar logger
             for j in progress.iter_bar(image_files=range(len(files_to_check))):
                 if not glob.glob(str(files_to_check[j])):
                     # use glob.glob for a file search to account for compund detectors of ESRFlvp detectors
                     missing_files.append(files_to_check[j])
                     missing_indicies.append(j)
                 else:
-                    logger.moreinfo(" ".join(map(str, [(f"{files_to_check[j]} exists.")])))
+                    logger.moreinfo(
+                        " ".join(map(str, [(f"{files_to_check[j]} exists.")]))
+                    )
 
             if len(missing_files) != 0:
                 if len(missing_files) <= 30:
@@ -672,7 +679,6 @@ class Settings:
                     )
             else:
                 logger.info(" ".join(map(str, [(f"{files_to_check[j]} exists.")])))
-
 
     def check_directory_exists(
         self,
@@ -689,7 +695,9 @@ class Settings:
                 )
             else:
                 os.makedirs(directory)
-                logger.info(" ".join(map(str, [(f"{directory.as_posix()!r} was created.")])))
+                logger.info(
+                    " ".join(map(str, [(f"{directory.as_posix()!r} was created.")]))
+                )
         else:
             logger.info(" ".join(map(str, [(f"{directory.as_posix()!r} exists.")])))
 
@@ -706,7 +714,6 @@ class Settings:
         report: Literal[
             "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
         ] = "INFO",
-
         peak=None,
         orders=None,
     ):
@@ -981,7 +988,6 @@ class Settings:
         report: Literal[
             "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
         ] = "INFO",
-
     ):
         """
         Checks that a set component type is valid -- i.e. it exists in PeakFunctions.
@@ -1223,7 +1229,6 @@ class Settings:
         else:
             logger.info(" ".join(map(str, [("fit_bounds appears to be correct")])))
 
-
     def set_output_types(
         self,
         out_type_list: list[str] = [],
@@ -1237,18 +1242,20 @@ class Settings:
         if out_type_list:
             self.output_types = get_output_options(out_type_list)
         elif "Output_type" in self.settings_from_input:
-            self.output_types = get_output_options(self.settings_from_input["Output_type"])
+            self.output_types = get_output_options(
+                self.settings_from_input["Output_type"]
+            )
         else:
             self.output_types = []
-            
-        # get the lists of required an optional values. 
-        # store in the settings. 
+
+        # get the lists of required an optional values.
+        # store in the settings.
         disagree = []
         required = []
         output_settings = {}
         for i in range(len(self.output_types)):
             wr = getattr(output_formatters, "Write" + self.output_types[i])
-            r,o = wr.Requirements()
+            r, o = wr.Requirements()
             # store all the required options to parse next
             required.extend(r)
             # filter optional settings in single dictionary.
@@ -1257,107 +1264,130 @@ class Settings:
                     # defaults are not in agreement
                     disagree.append(j)
                 output_settings[j] = o[j]
-        
+
         # parse output_* [old format for outputs]
         for j in output_settings:
-            if "output_"+j in self.settings_from_input:
-                output_settings[j] = self.settings_from_input["output_"+j]
-            elif "Output_"+j in self.settings_from_input:
-                output_settings[j] = self.settings_from_input["Output_"+j]
+            if "output_" + j in self.settings_from_input:
+                output_settings[j] = self.settings_from_input["output_" + j]
+            elif "Output_" + j in self.settings_from_input:
+                output_settings[j] = self.settings_from_input["Output_" + j]
             if j in disagree and j in list(self.settings_from_input):
                 disagree.remove(j)
             if j in required and j in list(self.settings_from_input):
                 required.remove(j)
         for j in required:
-            if "output_"+j in self.settings_from_input:
-                output_settings[j] = self.settings_from_input["output_"+j]
-            elif "Output_"+j in self.settings_from_input:
-                output_settings[j] = self.settings_from_input["Output_"+j]
+            if "output_" + j in self.settings_from_input:
+                output_settings[j] = self.settings_from_input["output_" + j]
+            elif "Output_" + j in self.settings_from_input:
+                output_settings[j] = self.settings_from_input["Output_" + j]
             if j in disagree and j in list(self.settings_from_input):
                 disagree.remove(j)
             if j in required and j in list(self.settings_from_input):
                 required.remove(j)
         # parse output_options dictionary [new format for outputs]
         # new style overrides old style
-        if "output_options" in [item.lower() for item in list(self.settings_from_input)]:
+        if "output_options" in [
+            item.lower() for item in list(self.settings_from_input)
+        ]:
             for key, value in self.settings_from_input["output_options"].items():
                 output_settings[key] = value
-                if key in disagree and key in list(self.settings_from_input["output_options"]):
+                if key in disagree and key in list(
+                    self.settings_from_input["output_options"]
+                ):
                     disagree.remove(key)
-                if key in required and key in list(self.settings_from_input["output_options"]):
+                if key in required and key in list(
+                    self.settings_from_input["output_options"]
+                ):
                     required.remove(key)
-            
+
             # for j in len(self.settings_from_input["output_options"]):
             #     output_settings[j] = self.settings_from_input.output_options[j]
             #     if j in disagree and j in list(self.settings_from_input.output_options):
             #         disagree.remove(j)
             #     if j in required and j in list(self.settings_from_input.output_options):
             #         required.remove(j)
-                    
+
         self.output_settings = output_settings
         if disagree:
-            logger.warning("There are conflicts between outputs for the following parameters:")
+            logger.warning(
+                "There are conflicts between outputs for the following parameters:"
+            )
             for i in range(len(disagree)):
                 logger.warning(f" {disagree[i]},")
-            logger.warning("The convlicting parameters listed above may prevent outputs being written as expected.")
+            logger.warning(
+                "The convlicting parameters listed above may prevent outputs being written as expected."
+            )
             logger.warning("These need to be changed.")
 
-            
-    def set_metadata(self,
-            report: Literal[
-                "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
-            ] = "INFO",
+    def set_metadata(
+        self,
+        report: Literal[
+            "DEBUG", "EFFUSIVE", "MOREINFO", "INFO", "WARNING", "ERROR"
+        ] = "INFO",
     ):
         """
         Adds list of metadata values, required by inputs, to class.
-        
+
         Parses input file and output file requirements to confirm all requirements are present.
-        
-        Results in self.metadata which defines what data is read and stored when processing the data. 
-        
+
+        Results in self.metadata which defines what data is read and stored when processing the data.
+
         Used by data_class.get_metadata.
-        
+
         """
         # get default labels if they exist.
-        if (self.data_class and 
-            "_default_metadata_labels" in self.data_class.__dict__):
+        if self.data_class and "_default_metadata_labels" in self.data_class.__dict__:
             self.metadata_labels.update(self.data_class._default_metadata_labels)
-        # use set values - if given 
+        # use set values - if given
         if "metadata_labels" in self.settings_from_input:
             self.metadata_labels.update(self.settings_from_input["metadata_labels"])
-            
+
         # get metadata from inputs
         if "metadata" in self.settings_from_input:
             if not isinstance(self.settings_from_input["metadata"], list):
-                self.settings_from_input["metadata"] = [self.settings_from_input["metadata"]]
-            self.metadata = list(set(self.metadata + self.settings_from_input["metadata"]))
+                self.settings_from_input["metadata"] = [
+                    self.settings_from_input["metadata"]
+                ]
+            self.metadata = list(
+                set(self.metadata + self.settings_from_input["metadata"])
+            )
         # make sure values from metadata_labels are in the list
         self.metadata = list(set(self.metadata + list(self.metadata_labels.values())))
 
-        # add metadata from h5_iterate if it exists. 
+        # add metadata from h5_iterate if it exists.
         if "h5_iterate" in self.settings_from_input:
             if self.h5_iterate[-1]["do"] != "sum":
                 for i in self.h5_iterate[-1]["label"]:
                     if "/" in i:
                         self.metadata.append(i)
-        
+
         # get metadata_read_func if it exists
         if "metadata_read_func" in self.settings_from_input:
             self.metadata_read_func = self.settings_from_input["metadata_read_func"]
             # pass settings as 'self'
-            self.metadata.extend(self.metadata_read_func(self,).keys())
+            self.metadata.extend(
+                self.metadata_read_func(
+                    self,
+                ).keys()
+            )
 
-        #replace all the wildcards in the metadata.        
+        # replace all the wildcards in the metadata.
         for i in range(len(self.metadata)):
             if "*" in self.metadata[i] and "/" not in self.metadata[i]:
-                if ("metadata" not in self.data_class.__dict__ or 
-                    (self.data_class.__dict__['metadata']==None) 
-                    ):
+                if "metadata" not in self.data_class.__dict__ or (
+                    self.data_class.__dict__["metadata"] == None
+                ):
                     self.data_class.fill_data(self.image_list[0], settings=self)
-                
+
                 # add all wildard catches to metadata
-                pattern = re.compile(re.sub('[*]', '([0-9a-zA-Z-+_:]*)', self.metadata[i]))  
-                matches = [word for word in list(self.data_class.metadata) if pattern.match(word)]
+                pattern = re.compile(
+                    re.sub("[*]", "([0-9a-zA-Z-+_:]*)", self.metadata[i])
+                )
+                matches = [
+                    word
+                    for word in list(self.data_class.metadata)
+                    if pattern.match(word)
+                ]
                 for j in range(len(matches)):
                     if j == 0:
                         self.metadata[i] = matches[j]
@@ -1365,20 +1395,20 @@ class Settings:
                         self.metadata.append(matches[j])
             else:
                 pass
-        
+
         # check for wildcards (*) and remove if another metadata corresponds
         remove = []
         for i in self.metadata:
             if "*" in i:
                 regex = re.compile(i.replace("*", ".*"))
                 filtered = [
-                    item for item in self.metadata
-                    if re.match(regex, item) # Checks if each item matches the regex.
+                    item
+                    for item in self.metadata
+                    if re.match(regex, item)  # Checks if each item matches the regex.
                 ]
                 if len(filtered) == 2:
                     remove.append(i)
         self.metadata = list(set(self.metadata) - set(remove))
-        
 
     def validate_output_types(self, report=False):
         """
@@ -1398,18 +1428,18 @@ class Settings:
                     "type exists."
                 )
 
-        # get the lists of required an optional values. 
-        # store in the settings. 
+        # get the lists of required an optional values.
+        # store in the settings.
         required = []
         optional = []
         for i in range(len(self.output_types)):
             wr = getattr(output_formatters, "Write" + self.output_types[i])
-            r,o = wr.Requirements()
+            r, o = wr.Requirements()
             # store all the required options to parse next
             required.extend(r)
             optional.extend(o)
-            
-        # list missing parameters            
+
+        # list missing parameters
         required = list(set(required) - set(list(self.output_settings)))
         optional = list(set(optional) - set(list(self.output_settings)))
 
@@ -1425,7 +1455,6 @@ class Settings:
             logger.warning("These parameters need to be set in order to proceed")
         else:
             logger.info("The output settings appear to be in order")
-
 
     def set_data_files(
         self,
@@ -1513,50 +1542,56 @@ class Settings:
 
         # make new order search list
         if isinstance(search_over, list) and len(search_over) == 2:
-            search = list(range(search_over[0], search_over[1]+1))
+            search = list(range(search_over[0], search_over[1] + 1))
         else:
             search = [int(x) for x in str(search_over)]
 
-        #search series
+        # search series
         if isinstance(search_series, str):
             search_series = [search_series]
         if search_series[0] == "all":
-            search_series = [coefficient_type_as_string(0),
-                             coefficient_type_as_string(1),
-                             coefficient_type_as_string(2),
-                             coefficient_type_as_string(3)]
+            search_series = [
+                coefficient_type_as_string(0),
+                coefficient_type_as_string(1),
+                coefficient_type_as_string(2),
+                coefficient_type_as_string(3),
+            ]
 
         orders_search = []
         for i in range(len(subpatterns)):
             tmp_order = self.fit_orders[subpatterns[i]]
             for j in range(len(search_series)):
-
-                if search_peak=="all":
+                if search_peak == "all":
                     peak_search = list(range(len(tmp_order["peak"])))
                 else:
                     peak_search = [search_peak]
 
                 for l in peak_search:
-
                     for k in range(len(search)):
-
                         orders_s = deepcopy(tmp_order)
                         if "background" not in search_parameter:
-                            if search_parameter not in peak_components(full=False, include_profile=True)[1]:
-                                raise ValueError("The search_parameter is not recognised.")
-                            orders_s["peak"][peak_search[l]][search_parameter] = search[k]
-                            orders_s["peak"][peak_search[l]][search_parameter + "_type"] = (
-                                search_series[j]
-                            )
-                        else: # "background" in search_parameter:
+                            if (
+                                search_parameter
+                                not in peak_components(
+                                    full=False, include_profile=True
+                                )[1]
+                            ):
+                                raise ValueError(
+                                    "The search_parameter is not recognised."
+                                )
+                            orders_s["peak"][peak_search[l]][search_parameter] = search[
+                                k
+                            ]
+                            orders_s["peak"][peak_search[l]][
+                                search_parameter + "_type"
+                            ] = search_series[j]
+                        else:  # "background" in search_parameter:
                             if search_parameter == "background":
                                 bg_pos = 0
                             else:
-                                bg_pos = int(re.sub("background","",search_parameter))
+                                bg_pos = int(re.sub("background", "", search_parameter))
                             orders_s["background"][bg_pos] = search[k]
-                            orders_s["background" + "_type"] = (
-                                search_series[j]
-                            )
+                            orders_s["background" + "_type"] = search_series[j]
                         if len(tmp_order) > 1:
                             intro_string = "peak=" + str(peak_search[l]) + "_"
                         else:
@@ -1625,9 +1660,7 @@ class Settings:
         else:
             return False
 
-    def save_settings(
-        self, filename: str = "settings.py", filepath: Path = Path(".")
-    ):
+    def save_settings(self, filename: str = "settings.py", filepath: Path = Path(".")):
         """
         Saves the settings class or dictionary to file.
 
@@ -1644,13 +1677,11 @@ class Settings:
 
         """
 
-
         # with open(filename, 'r') as tp_file:
         #      tp_file.write(json.dumps(self.__dict__))
 
         #      # print(values_write)
         # stop
-
 
         import re
 
@@ -1658,28 +1689,29 @@ class Settings:
         template_loc = os.path.join(os.path.dirname(__file__), template_file)
 
         # get template file.
-        with open(template_loc, 'r') as tp_file:
+        with open(template_loc, "r") as tp_file:
             template = tp_file.read()
-            values_write = re.findall(r'(\$\w+)', template)
+            values_write = re.findall(r"(\$\w+)", template)
 
-        #loop over the values_write and replace with values
+        # loop over the values_write and replace with values
         # Looping also makes easier to add or remove blocks of the setting file.
         for i in range(len(values_write)):
-
             # get value to write.
             d = {}
 
             if values_write[i][1:] in self.__dict__:
                 d[values_write[i][1:]] = self.__dict__[values_write[i][1:]]
             elif values_write[i][1:] in self.settings_from_input.__dict__:
-                d[values_write[i][1:]] = self.settings_from_input.__dict__[values_write[i][1:]]
+                d[values_write[i][1:]] = self.settings_from_input.__dict__[
+                    values_write[i][1:]
+                ]
             # else:
             #     try:
             #         d[values_write[i][1:]] = Settings().__dict__[values_write[i][1:]]
             #     except:
             #         d[values_write[i][1:]] = "Pah"
 
-            #if is not an acceptale type the convert to text.
+            # if is not an acceptale type the convert to text.
             if values_write[i][1:] in d:
                 if isinstance(d[values_write[i][1:]], list):
                     # convert list to json string.
@@ -1693,31 +1725,39 @@ class Settings:
                         pass
 
                 elif isinstance(d[values_write[i][1:]], dict):
-                    #convert dictionary to formatted string.
-                    template = template.replace(values_write[i], json.dumps(d[values_write[i][1:]]))
+                    # convert dictionary to formatted string.
+                    template = template.replace(
+                        values_write[i], json.dumps(d[values_write[i][1:]])
+                    )
 
                 elif isinstance(d[values_write[i][1:]], Path):
-
-                    template = template.replace(values_write[i], f"'{str(d[values_write[i][1:]])}'")
+                    template = template.replace(
+                        values_write[i], f"'{str(d[values_write[i][1:]])}'"
+                    )
 
                 elif isinstance(d[values_write[i][1:]], str):
-                    template = template.replace(values_write[i], f"'{d[values_write[i][1:]]}'")
+                    template = template.replace(
+                        values_write[i], f"'{d[values_write[i][1:]]}'"
+                    )
                 else:
-                    template = template.replace(values_write[i], f"{d[values_write[i][1:]]}")
+                    template = template.replace(
+                        values_write[i], f"{d[values_write[i][1:]]}"
+                    )
 
-
-        #remove lines that still have $ in them.
+        # remove lines that still have $ in them.
         template = template.splitlines(True)
         # remove deadlines
         for i in range(len(template)):
-            if re.findall(r'(\$\w+)', template[i]):
+            if re.findall(r"(\$\w+)", template[i]):
                 template[i] = ""
-        #recombine
-        template = ''.join(template)
+        # recombine
+        template = "".join(template)
 
-        #write settings file
+        # write settings file
         if self.settings_file:
-            filename = make_outfile_name(self.settings_file, extension="py", overwrite=False)
+            filename = make_outfile_name(
+                self.settings_file, extension="py", overwrite=False
+            )
         fnam = filepath / filename
         with open(fnam, "w") as TempFile:
             # Write to a text or py file.
@@ -1758,7 +1798,10 @@ def detector_factory(settings_class: Settings):
         detector_class = getattr(detector, def_def)
         return detector_class(settings_class=settings_class)
     else:
-        raise ValueError(f"Unrecognized calibration type, {settings_class.calibration_type}")
+        raise ValueError(
+            f"Unrecognized calibration type, {settings_class.calibration_type}"
+        )
+
 
 def is_settings(settings):
     """
@@ -1777,6 +1820,7 @@ def is_settings(settings):
     """
     import cpf
     import cpf.settings as sttng
+
     # the different ways of importing settings seems to give differnet answers.
     # therefore have to test all of them.
     if isinstance(settings, type(Settings())) == True:
@@ -1819,7 +1863,8 @@ def is_settings(settings):
 
 def get_settings(
     settings: [str | Path | dict | Settings()],
-    **kwargs,):
+    **kwargs,
+):
     """
 
 
@@ -1844,10 +1889,12 @@ def get_settings(
 
     """
     if settings is None:
-        err_str = "Either the settings file or the parameter dictionary need to be specified."
+        err_str = (
+            "Either the settings file or the parameter dictionary need to be specified."
+        )
         logger.error(err_str)
         raise ValueError(err_str)
-    elif is_settings(settings):#isinstance(settings, type(Settings())):
+    elif is_settings(settings):  # isinstance(settings, type(Settings())):
         # the settings input are already a setttings class.
         # validate the class.
         if settings.is_empty():
@@ -1858,7 +1905,7 @@ def get_settings(
             # only validate the setttings if changed.
             settings.validate_settings_file()
             settings_class = settings
-        else: #must be populated and valid.
+        else:  # must be populated and valid.
             settings_class = settings
     else:
         # initiate a settings class.
@@ -1874,7 +1921,6 @@ def get_settings(
         settings_class.populate(settings=settings, **kwargs)
 
     return settings_class
-
 
 
 if __name__ == "__main__":

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -466,9 +466,36 @@ def get_file_keys(
     return file_key_list, len(file_key_list)
 
 
+@overload
 def has_value(
-    obj: dict | list | pd.DataFrame | str | int | float,
+    obj: dict,
     val: str | int | float | None = None,
+    path: str = "",
+    is_present: bool = False,
+) -> bool: ...
+
+
+@overload
+def has_value(
+    obj: list,
+    val: str | int | float | None = None,
+    path: str = "",
+    is_present: bool = False,
+) -> bool: ...
+
+
+@overload
+def has_value(
+    obj: pd.DataFrame,
+    val: str | int | float | None = None,
+    path: str = "",
+    is_present: bool = False,
+) -> bool: ...
+
+
+def has_value(
+    obj: Any,
+    val: Any = None,
     path: str = "",
     is_present: bool = False,
 ):
@@ -479,14 +506,14 @@ def has_value(
 
     Parameters
     ----------
-    obj : dict, list, pd.DataFrame, str, int, float
-        Nested dictionary or list of parameters to inspect.
-    val : str, int, float, optional
+    obj : dict, list, pd.DataFrame
+        Nested dictionary/list of parameters or Pandas DataFrame to inspect.
+    val : str, int, float, None
         Value or string to find in the dictionary. The default is None.
     path : str
         Path taken through the dictionary/list. The default is "".
     is_present : bool
-        Boolian for if 'val' are in dictionary. Used for iterating through nested structures.
+        Boolean for if 'val' are in dictionary. Used for iterating through nested structures.
         The default is False.
 
     Returns
@@ -522,8 +549,8 @@ def has_value(
 @overload
 def replace_value(
     obj: dict,
-    old: Any = None,
-    new: Any = 0,
+    old: str | int | float | None = None,
+    new: str | int | float | None = 0,
     path: str = "",
 ) -> dict: ...
 
@@ -531,8 +558,8 @@ def replace_value(
 @overload
 def replace_value(
     obj: list,
-    old: Any = None,
-    new: Any = 0,
+    old: str | int | float | None = None,
+    new: str | int | float | None = 0,
     path: str = "",
 ) -> list: ...
 
@@ -540,8 +567,8 @@ def replace_value(
 @overload
 def replace_value(
     obj: pd.DataFrame,
-    old: Any = None,
-    new: Any = 0,
+    old: str | int | float | None = None,
+    new: str | int | float | None = 0,
     path: str = "",
 ) -> pd.DataFrame: ...
 

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -700,8 +700,12 @@ def peak_string(
     ----------
     orders: dict[str, list[dict[str, int | str]]]
         A nested dictionary containing information about the peaks to be fitted and
-        how to go about fitting them. The "peak" key contains a list of dictionaries
-        of the individual peaks to be fitted.
+        how to go about fitting them.
+        The "peak" key contains a list of dictionaries of the individual peaks to be
+        fitted. The dictionaries in turn should contain the 'hkl' key, which holds
+        the Miller indices in the form of a string or an integer array, as well as
+        the 'phase' key, which contains information about which material this peak
+        belongs to.
     peak: int | list[int] | str | Literal['all']
         The peaks to use to generate the peak string with. Takes an integer, a list of
         integers, a string of comma-separated numbers, or 'all'. The default is 'all'.
@@ -733,7 +737,7 @@ def peak_string(
     # Raise a TypeError otherwise
     else:
         raise TypeError(
-            f"'peak' received and unsupported value: {peak} "
+            f"'peak' received an unsupported value: {peak} "
             "It must be 'all', a string of comma-separated numbers, "
             "or a list of integers"
         )
@@ -743,7 +747,7 @@ def peak_string(
     for n, x in enumerate(peaks):
         # Determine name of peak from 'phase' key; fall back to using 'Peak'
         if "phase" in orders["peak"][x]:
-            p_str = p_str + peak_phase(orders, peak=x)[0]
+            p_str = p_str + str(peak_phase(orders, peak=x)[0])
         else:
             p_str = p_str + "Peak"
         # Encase indices in brackets if it's human-readable
@@ -753,7 +757,7 @@ def peak_string(
             p_str = p_str + "-"
         # Use Miller indices if 'hkl' key is present; fall back to auto-incrementing
         if "hkl" in orders["peak"][x]:
-            p_str = p_str + peak_hkl(orders, peak=x, string=True)[0]
+            p_str = p_str + str(peak_hkl(orders, peak=x, string=True)[0])
         else:
             p_str = p_str + str(x + 1)
         # Close the bracket if it's human-readable
@@ -768,46 +772,68 @@ def peak_string(
     return p_str
 
 
-def peak_hkl(orders, peak="all", string=True):
+def peak_hkl(
+    orders: dict[str, Any],
+    peak: int | list[int] | str | Literal["all"] = "all",
+    string: bool = True,
+) -> list[str | list[int]]:
     """
-    :param orders: list of peak orders which should include peak names/hkls
-    :param string: switch indicting if the output is a string or numeric list of hkl.
-    :param peak: switch to add restricted peaks to the output string
-    :return: string or list of peak hkl.
-    """
-    # possible hkl input formats:
-    #   string -- hkls as a string, generally used for hkls with leading 0 or negative hkl indicy
-    #   int -- hkls all positive and no leading 0
-    #   list -- e.g. [h,k,l]. New format.
-    # desired outputs:
-    #   string -- hkls as a string using String==True
-    #   list -- e.g. [h,k,l]. New format. using String==False
+    Parameters
+    ----------
+    orders: dict[str, list[dict[str, int | str]]]
+        A nested dictionary containing information about the peaks to be fitted and
+        how to go about fitting them.
+        The "peak" key contains a list of dictionaries of the individual peaks to be
+        fitted. The dictionaries in turn should contain the 'hkl' key, which holds
+        the Miller indices in the form of a string or an integer array.
+    peak: int | list[int] | str | Literal['all']
+        The peaks extract the hkl peaks from. Takes an integer, a list of integers,
+        a string of comma-separated numbers, or 'all'. The default is 'all'.
+    string: bool
+        Toggle whether to return the the Miller indices as a string or an array.
 
+    Returns
+    -------
+    out: list[str | list[int]]
+       The list of peaks selected, stored as either a list of strings or a list of
+       integer arrays.
+    """
+    # Construct list of peaks to parse
     if peak == "all":
-        peek = list(range(len(orders["peak"])))
-    elif not isinstance(peak, list):
-        peek = [int(x) for x in str(peak)]
+        peaks = list(range(len(orders["peak"])))
+    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
+        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
+    elif isinstance(peak, int):
+        peaks = [peak]
+    elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
+        peaks = peak
     else:
-        peek = peak
+        raise TypeError(
+            f"'peak' received an unsupported value: {peak} "
+            "It must be 'all', a string of comma-separated numbers, "
+            "or a list of integers"
+        )
 
-    out = []
-    for x in peek:
+    out: list[str | list[int]] = []
+    for x in peaks:
+        # Handle 0 and if no 'hkl' key is found
         if "hkl" in orders["peak"][x]:
             hkl = orders["peak"][x]["hkl"]
             if hkl == "0" or hkl == 0:
                 hkl = "000"
         else:
             hkl = "000"
-
+        # Convert peaks into strings
         if not isinstance(hkl, list) and string == True:
             # string in, string out
             out.append(str(hkl))
         elif isinstance(hkl, list) and string == True:
             # convert numbers to string
-            out_tmp = ""
+            hkl_string = ""
             for y in range(len(hkl)):
-                out_tmp = out_tmp + str(hkl[y])
-            out.append(out_tmp)
+                hkl_string = hkl_string + str(hkl[y])
+            out.append(hkl_string)
+        # Convert peaks into list of integers
         elif isinstance(hkl, list) and string == False:
             # list in, list out
             out.append(hkl)
@@ -833,7 +859,7 @@ def peak_hkl(orders, peak="all", string=True):
             else:
                 l = hkl[pos : pos + 1]
                 pos = pos + 1
-            out_tmp = [int(h), int(k), int(l)]
+            hkl_list = [int(h), int(k), int(l)]
             if len(hkl) > pos:
                 if hkl[pos] == "-":
                     m = hkl[pos : pos + 2]
@@ -841,9 +867,8 @@ def peak_hkl(orders, peak="all", string=True):
                 else:
                     m = hkl[pos : pos + 1]
                     pos = pos + 1
-                out_tmp.append(int(m))
-            out.append(out_tmp)
-
+                hkl_list.append(int(m))
+            out.append(hkl_list)
     return out
 
 

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -279,8 +279,8 @@ def image_list(fit_parameters, files_only=False):
     return diff_files, n_diff_files, image_list, n_images
 
 
-def get_file_keys(
-    param_dict: dict = None,
+def get_file_indices(
+    param_dict: dict | None = None,
     start_num: int | None = None,
     end_num: int | None = None,
     step: int = 1,
@@ -364,31 +364,27 @@ def get_file_keys(
 
     Returns
     -------
-    file_key_list : list
+    file_indices : list
         List of file or key numbers.
     numFKlist : list
-        Number of entries in file_key_list.
+        Number of entries in file_indices.
 
     """
-
-    # Store checks to see if correct parameters are provided
+    # Check once for existence of variables, then reuse
     has_files = files is not None
     has_keys = keys is not None
-    has_start_num = start_num is not None
-    has_end_num = end_num is not None
 
-    # Extract start/
-    file_key_list: list[int] = []
+    file_indices: list[int] = []
     if param_dict is not None:
         if isinstance(param_dict, dict):
             # if is a dictionary assume from hdf5 files.
             # dictionary from hdf5 functions
             if "from" in param_dict:
-                start_num = int(param_dict["from"])
+                start_num = param_dict["from"]
             if "to" in param_dict:
-                end_num = int(param_dict["to"])
+                end_num = param_dict["to"]
             if "step" in param_dict:
-                step = int(param_dict["step"])
+                step = param_dict["step"]
         else:
             if "start_num" in param_dict:
                 start_num = param_dict["datafile_StartNum"]
@@ -396,27 +392,26 @@ def get_file_keys(
                 end_num = param_dict["datafile_EndNum"]
             if "step" in param_dict:
                 step = param_dict["datafile_Step"]
-    elif has_files and has_keys:
-        raise ValueError("File and key lists cannot both be provided")
-    elif not has_files and not has_keys:
-        raise ValueError("Neither files, keys or start_num are defined")
     elif has_files and not has_keys:
-        file_key_list = files
+        file_indices = files
     elif has_keys and not has_files:
-        file_key_list = keys
-    elif not has_files and not has_keys and has_start_num:
+        file_indices = keys
+    elif not has_files and not has_keys and start_num is not None:
         pass
-    elif has_start_num and not has_end_num:
-        raise ValueError("end_num is not defined")
+    elif start_num is not None:
+        if end_num == None:
+            raise ValueError("end_num is not defined")
+    else:
+        raise ValueError("Neither files, keys or start_num are defined")
 
     # exclude negative numbers from start num and end_num.
     # this just makes life simpler.
-    if has_start_num and start_num < 0:
+    if start_num is not None and start_num < 0:
         raise ValueError("start_num must be greater than 0")
-    if has_end_num and end_num < 0:
+    if end_num is not None and end_num < 0:
         raise ValueError("end_num must be greater than 0")
 
-    if not file_key_list:
+    if not file_indices:
         # make Lst from start, stop and step.
         if start_num > end_num:
             start_num, end_num = end_num, start_num
@@ -424,23 +419,23 @@ def get_file_keys(
         else:
             end_num += 1
 
-        file_key_list = np.arange(start_num, end_num, np.abs(step))
+        file_indices = np.arange(start_num, end_num, np.abs(step))
         if step < 0:
             # reverse list
-            file_key_list = file_key_list[::-1]
+            file_indices = file_indices[::-1]
 
     # make maximal list
     # based on values in the list
-    if not has_start_num:
-        s = np.min(file_key_list)
+    if start_num is None:
+        s = np.min(file_indices)
     elif start_num == -1:
-        s = np.max(file_key_list)
+        s = np.max(file_indices)
     else:
         s = start_num
-    if not has_end_num:
-        e = np.max(file_key_list) + 1
+    if end_num is None:
+        e = np.max(file_indices) + 1
     elif start_num == -1:
-        s = np.min(file_key_list)
+        s = np.min(file_indices)
     else:
         e = end_num + 1
 
@@ -456,14 +451,14 @@ def get_file_keys(
     # cut Lst to allowed values
     if has_files and isinstance(files[0], str):
         # files is a list of strings
-        file_key_list = file_key_list[list_all]
+        file_indices = file_indices[list_all]
     else:
         # get list of matching values
-        file_key_list = [x for x in list_all if x in file_key_list]
+        file_indices = [x for x in list_all if x in file_indices]
         # collapse incase it is a list of np arrays
-        file_key_list = np.array(file_key_list)
+        file_indices = np.array(file_indices)
 
-    return file_key_list, len(file_key_list)
+    return file_indices, len(file_indices)
 
 
 @overload

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -12,7 +12,7 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -690,39 +690,77 @@ def has_huge_errors(obj: dict, min_ratio: int | float = 3, is_huge: bool = False
     return is_huge
 
 
-def peak_string(orders, fname=False, peak="all"):
+def peak_string(
+    orders: dict[str, Any],
+    peak: int | list[int] | str | Literal["all"] = "all",
+    fname=False,
+):
     """
-    :param orders: list of peak orders which should include peak names/hkls
-    :param fname: switch indicting if the string is to be a file name or not.
-    :param peak: switch to add restricted peaks to the output string
-    :return: string listing peak names
+    Parameters
+    ----------
+    orders: dict[str, list[dict[str, int | str]]]
+        A nested dictionary containing information about the peaks to be fitted and
+        how to go about fitting them. The "peak" key contains a list of dictionaries
+        of the individual peaks to be fitted.
+    peak: int | list[int] | str | Literal['all']
+        The peaks to use to generate the peak string with. Takes an integer, a list of
+        integers, a string of comma-separated numbers, or 'all'. The default is 'all'.
+    fname: bool
+        Toggle whether to construct a file name-compatible or human-readable string.
+        If true, peak indices will be placed in parentheses (e.g. Peak (110)), whereas
+        they will be written as 'Peak-110_' if it's set to False).
+        The default is False.
+
+    Returns
+    -------
+    p_str: str
+        A string listing the peaks processed by the function. They take the format
+        "Peak (110) & Peak (220) & ..." if 'fname' is set to False, and are returned
+        as "Peak-110_Peak-220_..." if 'fname' is True.
     """
+    # Construct list of indices to parse
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    elif not isinstance(peak, list):
-        peaks = [int(x) for x in str(peak)]
-    else:
+    # If a string of comma-separated integers is provided
+    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
+        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
+    # If an int was provided
+    elif isinstance(peak, int):
+        peaks = [peak]
+    # If a list of ints is provided
+    elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
         peaks = peak
+    # Raise a TypeError otherwise
+    else:
+        raise TypeError(
+            f"'peak' received and unsupported value: {peak} "
+            "It must be 'all', a string of comma-separated numbers, "
+            "or a list of integers"
+        )
+
+    # Construct peak string
     p_str = ""
-    for x in peaks:
+    for n, x in enumerate(peaks):
+        # Determine name of peak from 'phase' key; fall back to using 'Peak'
         if "phase" in orders["peak"][x]:
-            # p_str = p_str + orders["peak"][x]["phase"]
             p_str = p_str + peak_phase(orders, peak=x)[0]
         else:
             p_str = p_str + "Peak"
+        # Encase indices in brackets if it's human-readable
         if fname is False:
             p_str = p_str + " ("
         else:
             p_str = p_str + "-"
+        # Use Miller indices if 'hkl' key is present; fall back to auto-incrementing
         if "hkl" in orders["peak"][x]:
-            # p_str = p_str + str(orders["peak"][x]["hkl"])
             p_str = p_str + peak_hkl(orders, peak=x, string=True)[0]
         else:
             p_str = p_str + str(x + 1)
+        # Close the bracket if it's human-readable
         if fname is False:
             p_str = p_str + ")"
-
-        if peak == "all" and x < len(orders["peak"]) - 1 and len(orders["peak"]) > 1:
+        # Separate peaks using either '&' if human-readable or '_'
+        if len(peaks) > 1 and n < len(peaks) - 1:
             if fname is False:
                 p_str = p_str + " & "
             else:

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -12,9 +12,9 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
-import pandas as pd
 
 import numpy as np
+import pandas as pd
 
 from cpf.util.logging import get_logger
 
@@ -73,77 +73,6 @@ def json_numpy_serializer(o):
         )
 
 
-def image_list(fit_parameters, files_only=False):
-    """
-    From the Settings make a list of all the data images to be processed.
-    If the images are h5 type files a list of files is made first then the list is expanded for the images in the h5 files.
-
-    #FIXME: This function is called by the output writing scripts to make sure the file names are called consistently.
-
-
-    Parameters
-    ----------
-    fit_parameters : TYPE
-        DESCRIPTION.
-    fit_settings : TYPE
-        DESCRIPTION.
-
-    Returns
-    -------
-    None.
-
-    """
-
-    # Local import to avoid circular errors
-    import cpf.h5_functions as h5_functions
-
-    # make the file list
-    diff_files, n_diff_files = file_list(fit_parameters)
-
-    if files_only != True:
-        # iterate for h5 files.
-        image_list = []
-        if "h5_datakey" in fit_parameters:
-            # if new h5 format is present then call it.
-            for i in range(n_diff_files):
-                h5_list = h5_functions.get_image_keys_new(
-                    diff_files[i],
-                    h5key_data=fit_parameters["h5_datakey"],
-                    h5_iterate=fit_parameters["h5_iterate"],
-                )
-                for j in range(len(h5_list)):
-                    tmp = [diff_files[i]]
-                    tmp.extend(h5_list[j])
-                    image_list.append(tmp)
-    
-        elif "h5_key_list" in fit_parameters:
-            # if the input contains the old hdf5 file instircutions make the new
-            # dictionary based format and call that
-            h5datakey, h5iterations = h5_functions.update_key_structure(
-                fit_parameters
-            )
-            for i in range(n_diff_files):
-                h5_list = h5_functions.get_image_keys_new(
-                    diff_files[i],
-                    h5key_data=h5datakey,
-                    h5_iterate=h5iterations,
-                )
-                for j in range(len(h5_list)):
-                    tmp = [diff_files[i]]
-                    tmp.extend(h5_list[j])
-                    image_list.append(tmp)
-            
-        else:
-            image_list = diff_files
-    
-    else:
-        image_list = diff_files
-
-    n_images = len(image_list)
-
-    return diff_files, n_diff_files, image_list, n_images
-
-
 def file_list(fit_parameters):
     """
     From the Settings make a list of all the data files.
@@ -194,7 +123,9 @@ def file_list(fit_parameters):
 
     # Diffraction patterns -- make list of files
     diff_files = []
-    if "datafile_Files" not in list(fit_parameters) and "datafile_StartNum" not in list(fit_parameters):
+    if "datafile_Files" not in list(fit_parameters) and "datafile_StartNum" not in list(
+        fit_parameters
+    ):
         # There is only a single file because nothing else is defined
         n_diff_files = 1
         diff_files.append(
@@ -207,16 +138,19 @@ def file_list(fit_parameters):
         )
         # diff_files.append(
         #     os.path.abspath(
-        #         getattr(fit_settings, 'datafile_directory', '.')  
+        #         getattr(fit_settings, 'datafile_directory', '.')
         #         + os.sep
-        #         + getattr(fit_settings, 'datafile_Basename', '')  
-        #         + getattr(fit_settings, 'datafile_Ending', '')  
+        #         + getattr(fit_settings, 'datafile_Basename', '')
+        #         + getattr(fit_settings, 'datafile_Ending', '')
         #     )
         # )
     elif "datafile_Files" not in list(fit_parameters):
         n_diff_files = int(
             np.floor(
-                np.abs(fit_parameters["datafile_EndNum"] - fit_parameters["datafile_StartNum"])
+                np.abs(
+                    fit_parameters["datafile_EndNum"]
+                    - fit_parameters["datafile_StartNum"]
+                )
                 / np.abs(step)
             )
             + 1
@@ -228,9 +162,9 @@ def file_list(fit_parameters):
                     fit_parameters["datafile_NumDigit"]
                 )
             else:
-                n = str(fit_parameters["datafile_StartNum"] + (j * -np.abs(step))).zfill(
-                    fit_parameters["datafile_NumDigit"]
-                )
+                n = str(
+                    fit_parameters["datafile_StartNum"] + (j * -np.abs(step))
+                ).zfill(fit_parameters["datafile_NumDigit"])
             # Append diffraction pattern name and directory
             diff_files.append(
                 os.path.abspath(
@@ -245,7 +179,9 @@ def file_list(fit_parameters):
             diff_files = diff_files[::-1]
 
     elif "datafile_Files" in list(fit_parameters):
-        n_diff_files = int(np.round(len(fit_parameters["datafile_Files"]) / np.abs(step)))
+        n_diff_files = int(
+            np.round(len(fit_parameters["datafile_Files"]) / np.abs(step))
+        )
         for j in range(n_diff_files):
             # Make list of diffraction pattern names and no. of pattern
             if step < 0:
@@ -269,6 +205,75 @@ def file_list(fit_parameters):
     else:
         n_diff_files = int(len(fit_parameters["datafile_Files"]) / step + 1)
     return diff_files, n_diff_files
+
+
+def image_list(fit_parameters, files_only=False):
+    """
+    From the Settings make a list of all the data images to be processed.
+    If the images are h5 type files a list of files is made first then the list is expanded for the images in the h5 files.
+
+    #FIXME: This function is called by the output writing scripts to make sure the file names are called consistently.
+
+
+    Parameters
+    ----------
+    fit_parameters : TYPE
+        DESCRIPTION.
+    fit_settings : TYPE
+        DESCRIPTION.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    # Local import to avoid circular errors
+    import cpf.h5_functions as h5_functions
+
+    # make the file list
+    diff_files, n_diff_files = file_list(fit_parameters)
+
+    if files_only != True:
+        # iterate for h5 files.
+        image_list = []
+        if "h5_datakey" in fit_parameters:
+            # if new h5 format is present then call it.
+            for i in range(n_diff_files):
+                h5_list = h5_functions.get_image_keys_new(
+                    diff_files[i],
+                    h5key_data=fit_parameters["h5_datakey"],
+                    h5_iterate=fit_parameters["h5_iterate"],
+                )
+                for j in range(len(h5_list)):
+                    tmp = [diff_files[i]]
+                    tmp.extend(h5_list[j])
+                    image_list.append(tmp)
+
+        elif "h5_key_list" in fit_parameters:
+            # if the input contains the old hdf5 file instircutions make the new
+            # dictionary based format and call that
+            h5datakey, h5iterations = h5_functions.update_key_structure(fit_parameters)
+            for i in range(n_diff_files):
+                h5_list = h5_functions.get_image_keys_new(
+                    diff_files[i],
+                    h5key_data=h5datakey,
+                    h5_iterate=h5iterations,
+                )
+                for j in range(len(h5_list)):
+                    tmp = [diff_files[i]]
+                    tmp.extend(h5_list[j])
+                    image_list.append(tmp)
+
+        else:
+            image_list = diff_files
+
+    else:
+        image_list = diff_files
+
+    n_images = len(image_list)
+
+    return diff_files, n_diff_files, image_list, n_images
 
 
 def StartStopFilesToList(
@@ -499,7 +504,7 @@ def any_terms_null(obj_to_inspect, val_to_find=None, index_path="", any_null=Fal
         # look indata frame for values
         tf = (obj_to_inspect.values == val_to_find).any()
         any_null = tf or any_null
-        
+
     elif obj_to_inspect == val_to_find:
         any_null = True
         logger.moreinfo(
@@ -507,20 +512,18 @@ def any_terms_null(obj_to_inspect, val_to_find=None, index_path="", any_null=Fal
         )
         # could be verbose if verbose logger.
     else:
-        pass #all seems in order
-        
+        pass  # all seems in order
+
     return any_null
 
 
-def replace_null_terms(
-    obj_to_inspect, val_to_find=None, index_path="", replace_with=0
-):
+def replace_null_terms(obj_to_inspect, val_to_find=None, index_path="", replace_with=0):
     """
     This function accepts a nested dictionary and list as argument
     and iterates over all values of nested dictionaries and lists.
-    If any of the values are "Null" (or 'val_to_find') it replaces it with 
+    If any of the values are "Null" (or 'val_to_find') it replaces it with
     the value in 'replace_with'
-    
+
     Parameters
     ----------
     obj_to_inspect : dict, list
@@ -530,7 +533,7 @@ def replace_null_terms(
     index_path : str
         Index to look at in dictionary. The default is "".
     replace_with : str, float
-        Value or string to use as replacement in the dictionary. 
+        Value or string to use as replacement in the dictionary.
         The default is 0.
 
     Returns
@@ -545,28 +548,34 @@ def replace_null_terms(
     if isinstance(obj_to_inspect, dict):
         for key, value in obj_to_inspect.items():
             obj_to_inspect[key] = replace_null_terms(
-                deepcopy(value), val_to_find, index_path + f"['{key}']", replace_with=replace_with
+                deepcopy(value),
+                val_to_find,
+                index_path + f"['{key}']",
+                replace_with=replace_with,
             )
 
     elif isinstance(obj_to_inspect, list):
         for key, value in enumerate(obj_to_inspect):
             obj_to_inspect[key] = replace_null_terms(
-                deepcopy(value), val_to_find, index_path + f"[{key}]", replace_with=replace_with
+                deepcopy(value),
+                val_to_find,
+                index_path + f"[{key}]",
+                replace_with=replace_with,
             )
 
     elif isinstance(obj_to_inspect, pd.DataFrame):
         # replace contents of panda data frame
         if val_to_find is not None:
             obj_to_inspect = obj_to_inspect.replace(val_to_find, replace_with)
-            
-    elif obj_to_inspect == val_to_find:# and val_to_find is not None:
+
+    elif obj_to_inspect == val_to_find:  # and val_to_find is not None:
         obj_to_inspect = replace_with
         logger.moreinfo(
             " ".join(map(str, [(f"Value {val_to_find} found at {index_path}")]))
         )
-        
+
     else:
-        pass #everything is in order
+        pass  # everything is in order
 
     return obj_to_inspect
 
@@ -576,7 +585,7 @@ def any_errors_huge(obj_to_inspect, large_errors=3, any_huge=False):
     This function accepts a nested dictionary and list as argument
     and iterates over all values of nested dictionaries and lists.
     If any of the error values are more than scale times the fitted value it
-    flags the errors as huge    
+    flags the errors as huge
 
     Huge errors are flagged if:
         1. value_err/value >= large_errors
@@ -988,9 +997,9 @@ def licit_filename(fname, replacement="==", exclude_dir=True):
 
     # the file name might include a directory link...
     if exclude_dir == False:
-        fname=fname.replace("/",replacement)
-        fname=fname.replace("\\",replacement)
-    
+        fname = fname.replace("/", replacement)
+        fname = fname.replace("\\", replacement)
+
     fname = number_to_string(fname)
 
     return fname

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -698,13 +698,13 @@ def peak_string(orders, fname=False, peak="all"):
     :return: string listing peak names
     """
     if peak == "all":
-        peek = list(range(len(orders["peak"])))
+        peaks = list(range(len(orders["peak"])))
     elif not isinstance(peak, list):
-        peek = [int(x) for x in str(peak)]
+        peaks = [int(x) for x in str(peak)]
     else:
-        peek = peak
+        peaks = peak
     p_str = ""
-    for x in peek:
+    for x in peaks:
         if "phase" in orders["peak"][x]:
             # p_str = p_str + orders["peak"][x]["phase"]
             p_str = p_str + peak_phase(orders, peak=x)[0]

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -276,8 +276,13 @@ def image_list(fit_parameters, files_only=False):
     return diff_files, n_diff_files, image_list, n_images
 
 
-def StartStopFilesToList(
-    paramDict=None, StartNum=None, EndNum=None, Step=1, Files=None, Keys=None
+def get_file_keys(
+    param_dict: dict = None,
+    start_num: int | None = None,
+    end_num: int | None = None,
+    step: int = 1,
+    files: list[int] | None = None,
+    keys: list[int] | None = None,
 ):
     """
     Convert parameters into a list of numerical. Takes with a settings class, a
@@ -287,177 +292,175 @@ def StartStopFilesToList(
 
     The function cannot accept both keys and files in the same call.
 
-    The heirerarchy works as follow:
-    1. If Files (or keys) is given and StartNum,EndNum,Step are not given
+    The hierarchy works as follow:
+    1. If files (or keys) is given and start_num, end_num, step are not given
     the contents of files/keys is returned.
-    2. If Files (or keys) is given and StartNum, EndNum or Step are also given
-    files/keys are trimmed to values between StartNum and EndNum using Step.
-    - if only Step and Step = -1, the order of Files/Keys is reversed.
-    3. If only StartNum, EndNum +/- Step are given a list of numbers is
+    2. If files (or keys) is given and start_num, end_num or step are also given
+    files/keys are trimmed to values between start_num and end_num using step.
+    - if only step and step = -1, the order of files/keys is reversed.
+    3. If only start_num, end_num +/- step are given a list of numbers is
     made from these values.
-    - StartNum is  present in the file list if step > 0
-    - EndNum is present in the list if Step < 0
+    - start_num is present in the file list if step > 0
+    - end_num is present in the list if step < 0
 
     e.g.
-    A.  Files = [1,3,4,6,7,9,10]
+    A.  files = [1,3,4,6,7,9,10]
         gives: [1,3,4,6,7,9,10]
 
-    B.  Files = [1,3,4,6,7,9,10]
-        StartNum = 2
-        EndNum   = 9
+    B.  files = [1,3,4,6,7,9,10]
+        start_num = 2
+        end_num   = 9
         gives: [3,4,6,7,9]
 
-    C.  Files = [1,3,4,6,7,9,10]
-        StartNum = 2
-        EndNum   = 9
+    C.  files = [1,3,4,6,7,9,10]
+        start_num = 2
+        end_num   = 9
         step = -1
         gives: [9,7,6,4,3]
 
-    D.  StartNum = 1
-        EndNum   = 10
+    D.  start_num = 1
+        end_num   = 10
         step = 1
         gives: 1,2,3,4,5,6,7,8,9,10
 
-    E.  StartNum = 1
-        EndNum   = 10
+    E.  start_num = 1
+        end_num   = 10
         step = 4
         gives: 1,5,9
 
-    F.  StartNum = 1
-        EndNum   = 10
+    F.  start_num = 1
+        end_num   = 10
         step = -4
         gives: 9,5,1
 
-    G.  StartNum = 10
-        EndNum   = 1
+    G.  start_num = 10
+        end_num   = 1
         step = 4
         gives: 10,6,2
 
-    H.  StartNum = 10
-        EndNum   = 1
+    H.  start_num = 10
+        end_num   = 1
         step = -4
         gives: 2,6,10
 
 
-
     Parameters
     ----------
-    paramDict : TYPE, optional
+    param_dict : TYPE, optional
         DESCRIPTION. The default is None.
-    StartNum : float, optional
+    start_num : int, optional
         Starting value for the file index/number. The default is None.
-    EndNum : float, optional
+    end_num : int, optional
         End value for the file index/number. The default is None.
-    Step : int, optional
-        Step value for the indices. The default is 1.
-    Files : list, optional
+    step : int, optional
+        step value for the indices. The default is 1.
+    files : list, optional
         List of file indices. The default is None.
-    Keys : list, optional
+    keys : list, optional
         List of key indices for hdf5 file. The default is None.
 
     Returns
     -------
-    FKlist : list
+    file_key_list : list
         List of file or key numbers.
     numFKlist : list
-        Number of entries in FKlist.
+        Number of entries in file_key_list.
 
     """
 
-    if paramDict != None:
-        if isinstance(paramDict, dict):
+    # Store checks to see if correct parameters are provided
+    has_files = files is not None
+    has_keys = keys is not None
+    has_start_num = start_num is not None
+    has_end_num = end_num is not None
+
+    # Extract start/
+    file_key_list: list[int] = []
+    if param_dict is not None:
+        if isinstance(param_dict, dict):
             # if is a dictionary assume from hdf5 files.
             # dictionary from hdf5 functions
-            if "from" in paramDict:
-                StartNum = paramDict["from"]
-            if "to" in paramDict:
-                EndNum = paramDict["to"]
-            if "step" in paramDict:
-                Step = paramDict["step"]
+            if "from" in param_dict:
+                start_num = int(param_dict["from"])
+            if "to" in param_dict:
+                end_num = int(param_dict["to"])
+            if "step" in param_dict:
+                step = int(param_dict["step"])
         else:
-            if "StartNum" in paramDict:
-                From = paramDict["datafile_StartNum"]
-            if "EndNum" in paramDict:
-                To = paramDict["datafile_EndNum"]
-            if "Step" in paramDict:
-                Step = paramDict["datafile_Step"]
-
-        if Keys != True:
-            # get information for Files
-            pass
-        else:
-            # get information for hdf5 keys
-            pass
+            if "start_num" in param_dict:
+                start_num = param_dict["datafile_StartNum"]
+            if "end_num" in param_dict:
+                end_num = param_dict["datafile_EndNum"]
+            if "step" in param_dict:
+                step = param_dict["datafile_Step"]
+    elif has_files and has_keys:
+        raise ValueError("File and key lists cannot both be provided")
+    elif not has_files and not has_keys:
+        raise ValueError("Neither files, keys or start_num are defined")
+    elif has_files and not has_keys:
+        file_key_list = files
+    elif has_keys and not has_files:
+        file_key_list = keys
+    elif not has_files and not has_keys and has_start_num:
         pass
-        FKlist = []
-    elif Files != None and Keys == None:
-        FKlist = Files
-    elif Files == None and Keys != None:
-        FKlist = Keys
-    elif Files == None and Keys == None and StartNum != None:
-        FKlist = []
-    elif StartNum != None:
-        FKlist = []
-        if EndNum == None:
-            raise ValueError("EndNum is not defined")
-    else:
-        raise ValueError("Neither Files, Keys or StartNum are defined")
+    elif has_start_num and not has_end_num:
+        raise ValueError("end_num is not defined")
 
-    # exclude negative numbers from start num and EndNum.
+    # exclude negative numbers from start num and end_num.
     # this just makes life simpler.
-    if StartNum != None and StartNum < 0:
-        raise ValueError("StartNum must be greater than 0")
-    if EndNum != None and EndNum < 0:
-        raise ValueError("EndNum must be greater than 0")
+    if has_start_num and start_num < 0:
+        raise ValueError("start_num must be greater than 0")
+    if has_end_num and end_num < 0:
+        raise ValueError("end_num must be greater than 0")
 
-    if FKlist == []:
+    if not file_key_list:
         # make Lst from start, stop and step.
-        if StartNum > EndNum:
-            StartNum, EndNum = EndNum, StartNum
-            EndNum -= 1
+        if start_num > end_num:
+            start_num, end_num = end_num, start_num
+            end_num -= 1
         else:
-            EndNum += 1
+            end_num += 1
 
-        FKlist = np.arange(StartNum, EndNum, np.abs(Step))
-        if Step < 0:
+        file_key_list = np.arange(start_num, end_num, np.abs(step))
+        if step < 0:
             # reverse list
-            FKlist = FKlist[::-1]
+            file_key_list = file_key_list[::-1]
 
     # make maximal list
     # based on values in the list
-    if StartNum == None:
-        s = np.min(FKlist)
-    elif StartNum == -1:
-        s = np.max(FKlist)
+    if not has_start_num:
+        s = np.min(file_key_list)
+    elif start_num == -1:
+        s = np.max(file_key_list)
     else:
-        s = StartNum
-    if EndNum == None:
-        e = np.max(FKlist) + 1
-    elif StartNum == -1:
-        s = np.min(FKlist)
+        s = start_num
+    if not has_end_num:
+        e = np.max(file_key_list) + 1
+    elif start_num == -1:
+        s = np.min(file_key_list)
     else:
-        e = EndNum + 1
+        e = end_num + 1
 
     if s > e:
         s, e = e, s
     #     e -= 1
     else:
         e += 1
-    LstAll = np.arange(s, e + 1, np.abs(Step))
-    if Step < 0:
+    list_all = np.arange(s, e + 1, np.abs(step))
+    if step < 0:
         # reverse list
-        LstAll = LstAll[::-1]
+        list_all = list_all[::-1]
     # cut Lst to allowed values
-    if Files != None and isinstance(Files[0], str):
+    if has_files and isinstance(files[0], str):
         # files is a list of strings
-        FKlist = FKlist[LstAll]
+        file_key_list = file_key_list[list_all]
     else:
         # get list of matching values
-        FKlist = [x for x in LstAll if x in FKlist]
+        file_key_list = [x for x in list_all if x in file_key_list]
         # collapse incase it is a list of np arrays
-        FKlist = np.array(FKlist)
+        file_key_list = np.array(file_key_list)
 
-    return FKlist, len(FKlist)
+    return file_key_list, len(file_key_list)
 
 
 def any_terms_null(obj_to_inspect, val_to_find=None, index_path="", any_null=False):

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -517,7 +517,7 @@ def has_value(
     return is_present
 
 
-def replace_null_terms(obj_to_inspect, val_to_find=None, index_path="", replace_with=0):
+def replace_value(obj_to_inspect, val_to_find=None, index_path="", replace_with=0):
     """
     This function accepts a nested dictionary and list as argument
     and iterates over all values of nested dictionaries and lists.
@@ -547,7 +547,7 @@ def replace_null_terms(obj_to_inspect, val_to_find=None, index_path="", replace_
 
     if isinstance(obj_to_inspect, dict):
         for key, value in obj_to_inspect.items():
-            obj_to_inspect[key] = replace_null_terms(
+            obj_to_inspect[key] = replace_value(
                 deepcopy(value),
                 val_to_find,
                 index_path + f"['{key}']",
@@ -556,7 +556,7 @@ def replace_null_terms(obj_to_inspect, val_to_find=None, index_path="", replace_
 
     elif isinstance(obj_to_inspect, list):
         for key, value in enumerate(obj_to_inspect):
-            obj_to_inspect[key] = replace_null_terms(
+            obj_to_inspect[key] = replace_value(
                 deepcopy(value),
                 val_to_find,
                 index_path + f"[{key}]",

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -874,33 +874,45 @@ def peak_hkl(
 
 def peak_phase(orders, peak="all"):
     """
-    :param orders: list of peak orders which should include peak names/hkls
-    :param string: switch indicting if the output is a string or numeric list of hkl.
-    :param peak: switch to add restricted peaks to the output string
-    :return: string or list of peak hkl.
+    Parameters
+    ----------
+    orders: dict[str, list[dict[str, int | str]]]
+        A nested dictionary containing information about the peaks to be fitted and
+        how to go about fitting them.
+        The "peak" key contains a list of dictionaries of the individual peaks to be
+        fitted. The dictionaries in turn should contain the 'phase' key, which holds
+        the name of the phase/material this peak belongs to.
+    peak: int | list[int] | str | Literal['all']
+        The peaks extract the hkl peaks from. Takes an integer, a list of integers,
+        a string of comma-separated numbers, or 'all'. The default is 'all'.
+
+    Returns
+    -------
+    out: list[str]
+       The list of phase names for the selected peaks.
     """
-    # possible hkl input formats:
-    #   string -- hkls as a string, generally used for hkls with leading 0 or negative hkl indicy
-    #   int -- hkls all positive and no leading 0
-    #   list -- e.g. [h,k,l]. New format.
-    # desired outputs:
-    #   string -- hkls as a string using String==True
-    #   list -- e.g. [h,k,l]. New format. using String==False
-
+    # Convert input into a list of integers
     if peak == "all":
-        peek = list(range(len(orders["peak"])))
-    elif not isinstance(peak, list):
-        peek = [int(x) for x in str(peak)]
+        peaks = list(range(len(orders["peak"])))
+    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
+        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
+    elif isinstance(peak, int):
+        peaks = [peak]
+    elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
+        peaks = peak
     else:
-        peek = peak
-
-    out = []
-    for x in peek:
+        raise TypeError(
+            f"'peak' received an unsupported value: {peak} "
+            "It must be 'all', a string of comma-separated numbers, "
+            "or a list of integers"
+        )
+    # Load names of specified phases, with a fallback to 'Unknown'
+    out: list[str] = []
+    for x in peaks:
         if "phase" in orders["peak"][x]:
             out.append(orders["peak"][x]["phase"])
         else:
             out.append("Unknown")
-
     return out
 
 

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -17,9 +17,10 @@ from typing import Any, TypeVar, overload
 import numpy as np
 import pandas as pd
 
+import cpf.peak_functions as pf
 from cpf.util.logging import get_logger
 
-logger = get_logger("cpf.IO_functions")
+logger = get_logger("cpf.util.io")
 
 T = TypeVar("T")
 
@@ -612,109 +613,81 @@ def replace_value(
     return obj
 
 
-def has_huge_errors(obj_to_inspect, large_errors=3, any_huge=False):
+def has_huge_errors(obj: dict, min_ratio: int | float = 3, is_huge: bool = False):
     """
-    This function accepts a nested dictionary and list as argument
-    and iterates over all values of nested dictionaries and lists.
-    If any of the error values are more than scale times the fitted value it
-    flags the errors as huge
+    This function accepts a nested dictionary and list as argument and iterates over
+    all values of nested dictionaries and lists.
 
     Huge errors are flagged if:
-        1. value_err/value >= large_errors
+        1. value_err/value >= min_ratio
         2. abs(value)-value_err >= 0  (i.e. not within error of 0)
 
     Parameters
     ----------
-    obj_to_inspect : dict, list
-        Nested dictionary or list of parameters to inspect.
-    large_errors : float, optional
-        Scale factor for how big large errors are before being flagged. The default is 3.
-    any_huge : bool, optional
-        Boolian for if large errors are found. Used for iterating through nested structures.
+    obj : dict
+        Nested dictionary of parameters to inspect.
+    min_ratio : float
+        Minimum ratio for how big large errors are before being flagged. The default is 3.
+    is_huge : bool
+        Boolean for if large errors are found. Used for iterating through nested structures.
         The default is False.
 
     Returns
     -------
-    any_huge : bool
+    is_huge : bool
         True - if large errors have been found in the dicionary
         False - if no large errors are present.
 
     """
-
-    # Local import to avoid circular import errors
-    import cpf.peak_functions as pf
-
-    for k in range(len(obj_to_inspect["background"])):
-        for j in range(len(obj_to_inspect["background"][k])):
+    for k in range(len(obj["background"])):
+        for j in range(len(obj["background"][k])):
             if (
-                obj_to_inspect["background"][k][j] != 0
-                and obj_to_inspect["background"][k][j] != None
-                and obj_to_inspect["background_err"][k][j] != 0
-                and obj_to_inspect["background_err"][k][j] != None
-                and obj_to_inspect["background_err"][k][j]
-                / obj_to_inspect["background"][k][j]
-                >= large_errors
+                obj["background"][k][j] != 0
+                and obj["background"][k][j] != None
+                and obj["background_err"][k][j] != 0
+                and obj["background_err"][k][j] != None
+                and obj["background_err"][k][j] / obj["background"][k][j] >= min_ratio
             ):
-                any_huge = True
-                err_rat = (
-                    obj_to_inspect["background_err"][k][j]
-                    / obj_to_inspect["background"][k][j]
-                )
+                is_huge = True
+                err_rat = obj["background_err"][k][j] / obj["background"][k][j]
                 logger.moreinfo(
-                    " ".join(
-                        map(
-                            str,
-                            [
-                                (
-                                    f"Huge errors found in background {k}, {j}: value= {obj_to_inspect['background'][k][j]: 3.2e}; error={obj_to_inspect['background_err'][k][j]: 3.2e}; fractional error = {err_rat: 5.1f}"
-                                )
-                            ],
-                        )
-                    )
+                    f"Huge errors found in background {k}, {j}: "
+                    f"value= {obj['background'][k][j]: 3.2e}; "
+                    f"error={obj['background_err'][k][j]: 3.2e}; "
+                    f"fractional error = {err_rat: 5.1f}"
                 )
-
     comp_list, comp_names = pf.peak_components(include_profile=True)
-    for k in range(len(obj_to_inspect["peak"])):
+    for k in range(len(obj["peak"])):
         for cp in range(len(comp_list)):
             comp = comp_names[cp]
-            for j in range(len(obj_to_inspect["peak"][k][comp])):
+            for j in range(len(obj["peak"][k][comp])):
                 # check if
                 # - there is a value and an error
-                # - the error is less than "large_errors" * error
+                # - the error is less than "min_ratio" * error
                 # - the value is not within error of 0
                 #       [this is a sanity check to the preceeding check -- the ratio of error/value tends to inifinty as the
                 #         value becomes very small.]
                 #       [without this there is lots of discarding the previous fit when the profile values are close to 0]
                 if (
-                    obj_to_inspect["peak"][k][comp][j] != 0
-                    and obj_to_inspect["peak"][k][comp][j] != None
-                    and obj_to_inspect["peak"][k][comp + "_err"][j] != 0
-                    and obj_to_inspect["peak"][k][comp + "_err"][j] != None
-                    and obj_to_inspect["peak"][k][comp + "_err"][j]
-                    / obj_to_inspect["peak"][k][comp][j]
-                    >= large_errors
-                    and np.abs(obj_to_inspect["peak"][k][comp][j])
-                    - obj_to_inspect["peak"][k][comp + "_err"][j]
+                    obj["peak"][k][comp][j] != 0
+                    and obj["peak"][k][comp][j] != None
+                    and obj["peak"][k][comp + "_err"][j] != 0
+                    and obj["peak"][k][comp + "_err"][j] != None
+                    and obj["peak"][k][comp + "_err"][j] / obj["peak"][k][comp][j]
+                    >= min_ratio
+                    and np.abs(obj["peak"][k][comp][j])
+                    - obj["peak"][k][comp + "_err"][j]
                     >= 0
                 ):
-                    any_huge = True
-                    err_rat = (
-                        obj_to_inspect["peak"][k][comp + "_err"][j]
-                        / obj_to_inspect["peak"][k][comp][j]
-                    )
+                    is_huge = True
+                    err_rat = obj["peak"][k][comp + "_err"][j] / obj["peak"][k][comp][j]
                     logger.moreinfo(
-                        " ".join(
-                            map(
-                                str,
-                                [
-                                    (
-                                        f"Huge error found in peak {k}, {comp} {j}: value= {obj_to_inspect['peak'][k][comp][j]: 3.2e}; error={obj_to_inspect['peak'][k][comp+'_err'][j]: 3.2e}; fractional error = {err_rat: 5.1f}"
-                                    )
-                                ],
-                            )
-                        )
+                        f"Huge error found in peak {k}, {comp} {j}: "
+                        f"value= {obj['peak'][k][comp][j]: 3.2e}; "
+                        f"error={obj['peak'][k][comp+'_err'][j]: 3.2e}; "
+                        f"fractional error = {err_rat: 5.1f}"
                     )
-    return any_huge
+    return is_huge
 
 
 def peak_string(orders, fname=False, peak="all"):

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -872,7 +872,7 @@ def peak_hkl(
         peaks = list(range(len(orders["peak"])))
     elif isinstance(peak, int):
         peaks = [peak]
-    elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
+    elif isinstance(peak, list) and all(np.issubdtype(x, np.integer) for x in peak):
         peaks = peak
     else:
         raise TypeError(
@@ -970,7 +970,7 @@ def peak_phase(
         peaks = list(range(len(orders["peak"])))
     elif isinstance(peak, int):
         peaks = [peak]
-    elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
+    elif isinstance(peak, list) and all(np.issubdtype(x, np.integer) for x in peak):
         peaks = peak
     else:
         raise TypeError(

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -692,7 +692,7 @@ def has_huge_errors(obj: dict, min_ratio: int | float = 3, is_huge: bool = False
 
 def peak_string(
     orders: dict[str, Any],
-    peak: int | list[int] | str | Literal["all"] = "all",
+    peak: int | list[int] | Literal["all"] = "all",
     fname=False,
 ):
     """
@@ -707,8 +707,8 @@ def peak_string(
         the 'phase' key, which contains information about which material this peak
         belongs to.
     peak: int | list[int] | str | Literal['all']
-        The peaks to use to generate the peak string with. Takes an integer, a list of
-        integers, a string of comma-separated numbers, or 'all'. The default is 'all'.
+        Indices of the peak descriptors to use to generate the peak string with.
+        Takes an integer, a list of integers, or 'all'. The default is 'all'.
     fname: bool
         Toggle whether to construct a file name-compatible or human-readable string.
         If true, peak indices will be placed in parentheses (e.g. Peak (110)), whereas
@@ -725,9 +725,6 @@ def peak_string(
     # Construct list of indices to parse
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    # If a string of comma-separated integers is provided
-    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
-        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
     # If an int was provided
     elif isinstance(peak, int):
         peaks = [peak]
@@ -738,8 +735,7 @@ def peak_string(
     else:
         raise TypeError(
             f"'peak' received an unsupported value: {peak} "
-            "It must be 'all', a string of comma-separated numbers, "
-            "or a list of integers"
+            "It must be 'all', an integer, or a list of integers. "
         )
 
     # Construct peak string
@@ -757,7 +753,7 @@ def peak_string(
             p_str = p_str + "-"
         # Use Miller indices if 'hkl' key is present; fall back to auto-incrementing
         if "hkl" in orders["peak"][x]:
-            p_str = p_str + str(peak_hkl(orders, peak=x, string=True)[0])
+            p_str = p_str + str(peak_hkl(orders, peak=x, as_string=True)[0])
         else:
             p_str = p_str + str(x + 1)
         # Close the bracket if it's human-readable
@@ -774,10 +770,25 @@ def peak_string(
 
 def peak_hkl(
     orders: dict[str, Any],
-    peak: int | list[int] | str | Literal["all"] = "all",
-    string: bool = True,
+    peak: int | list[int] | Literal["all"] = "all",
+    as_string: bool = True,
 ) -> list[str | list[int]]:
     """
+    Takes the values stored under the 'hkl' keys in the desired peak descriptors (which
+    are stored as a list of dictionaries under the 'peak' key in 'fit_orders') and
+    returns them as a list of Miller indices. If 'as_string' is True, the indices are
+    returned as filename-friendly strings. Otherwise, they are integer arrays.
+
+    Possible data types stored in 'hkl':
+    * string -- hkls are stored as a string. Generally used for indices with a leading
+    0 or with negative indices. E.g. "-110", "001"
+    * int --  hkls are all positive, with no leading 0. E.g. 100, 200
+    * list -- hkls are stored as a list of ints. E.g. [-1, 1, 0]
+
+    Possible outputs:
+    * string -- Contents of the returned list are strings. E.g. ["-110", "220"]
+    * list -- Contents of the list are integer arrays. E.g. [[1, 1, 0], ...]
+
     Parameters
     ----------
     orders: dict[str, list[dict[str, int | str]]]
@@ -786,11 +797,11 @@ def peak_hkl(
         The "peak" key contains a list of dictionaries of the individual peaks to be
         fitted. The dictionaries in turn should contain the 'hkl' key, which holds
         the Miller indices in the form of a string or an integer array.
-    peak: int | list[int] | str | Literal['all']
-        The peaks extract the hkl peaks from. Takes an integer, a list of integers,
-        a string of comma-separated numbers, or 'all'. The default is 'all'.
-    string: bool
-        Toggle whether to return the the Miller indices as a string or an array.
+    peak: int | list[int] | Literal['all']
+        Indices of the peak descriptors to extract the hkl peaks from. Takes an
+        integer, a list of integers, or 'all'. The default is 'all'.
+    as_string: bool
+        Toggle whether to return the Miller indices as a string or a list of integers.
 
     Returns
     -------
@@ -801,8 +812,6 @@ def peak_hkl(
     # Construct list of peaks to parse
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
-        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
     elif isinstance(peak, int):
         peaks = [peak]
     elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
@@ -810,8 +819,7 @@ def peak_hkl(
     else:
         raise TypeError(
             f"'peak' received an unsupported value: {peak} "
-            "It must be 'all', a string of comma-separated numbers, "
-            "or a list of integers"
+            "It must be 'all', an integer, or a list of integers. "
         )
 
     out: list[str | list[int]] = []
@@ -823,22 +831,22 @@ def peak_hkl(
                 hkl = "000"
         else:
             hkl = "000"
-        # Convert peaks into strings
-        if not isinstance(hkl, list) and string == True:
-            # string in, string out
+        # Store peaks as strings
+        if not isinstance(hkl, list) and as_string == True:
+            # String in, string out
             out.append(str(hkl))
-        elif isinstance(hkl, list) and string == True:
-            # convert numbers to string
+        elif isinstance(hkl, list) and as_string == True:
+            # List in, string out
             hkl_string = ""
             for y in range(len(hkl)):
                 hkl_string = hkl_string + str(hkl[y])
             out.append(hkl_string)
-        # Convert peaks into list of integers
-        elif isinstance(hkl, list) and string == False:
-            # list in, list out
+        # Store peaks as lists of integers
+        elif isinstance(hkl, list) and as_string == False:
+            # List in, list out
             out.append(hkl)
-        elif not isinstance(hkl, list) and string == False:
-            # convert string to array
+        elif not isinstance(hkl, list) and as_string == False:
+            # String in, list out
             pos = 0
             hkl = str(hkl)
             if hkl[0] == "-":
@@ -872,8 +880,16 @@ def peak_hkl(
     return out
 
 
-def peak_phase(orders, peak="all"):
+def peak_phase(
+    orders: dict[str, Any],
+    peak: int | list[int] | Literal["all"] = "all",
+):
     """
+    Extracts and returns the values stored under the 'phase' keys in the desired peak
+    descriptors (which are stored as a list of dictionaries under the 'peak' key in
+    'fit_orders') and returns them as a list of strings. If the 'phase' key is not
+    present, returns 'Unknown' as the phase name instead.
+
     Parameters
     ----------
     orders: dict[str, list[dict[str, int | str]]]
@@ -882,9 +898,9 @@ def peak_phase(orders, peak="all"):
         The "peak" key contains a list of dictionaries of the individual peaks to be
         fitted. The dictionaries in turn should contain the 'phase' key, which holds
         the name of the phase/material this peak belongs to.
-    peak: int | list[int] | str | Literal['all']
-        The peaks extract the hkl peaks from. Takes an integer, a list of integers,
-        a string of comma-separated numbers, or 'all'. The default is 'all'.
+    peak: int | list[int] | Literal['all']
+        The indices of the peak descriptors to extract the phase name from. Takes an
+        integer, a list of integers, or 'all'. The default is 'all'.
 
     Returns
     -------
@@ -894,8 +910,6 @@ def peak_phase(orders, peak="all"):
     # Convert input into a list of integers
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    elif isinstance(peak, str) and re.fullmatch(r"[0-9,\s]+", peak):
-        peaks = [int(x_strip) for x in peak.split(",") if (x_strip := x.strip())]
     elif isinstance(peak, int):
         peaks = [peak]
     elif isinstance(peak, list) and all(isinstance(x, int) for x in peak):
@@ -903,8 +917,7 @@ def peak_phase(orders, peak="all"):
     else:
         raise TypeError(
             f"'peak' received an unsupported value: {peak} "
-            "It must be 'all', a string of comma-separated numbers, "
-            "or a list of integers"
+            "It must be 'all', an integer, or a list of integers. "
         )
     # Load names of specified phases, with a fallback to 'Unknown'
     out: list[str] = []

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -289,12 +289,28 @@ def get_file_indices(
     keys: list[int] | None = None,
 ):
     """
-    Convert parameters into a list of numerical. Takes with a settings class, a
-    dictionary or start, stop, step and files directly.
+    Converts parameters into a list of numbers corresponding to the file numbers
+    or HDF5 keys of the data to be processed.
 
-    It works on either file names or keys for h5 files.
+    The parameters can come from a Settings class, a dictionary, or the 'start',
+    'stop', 'step', 'files', and 'keys' parameters directly.
 
-    The function cannot accept both keys and files in the same call.
+    If 'param_dict' is populated, the 'start', 'stop' and 'step' values should be
+    derived entirely from it. All other parameters will be ignored.
+
+    Other supported combinations of parameters include:
+    - 'files'
+    - 'files', 'step'
+    - 'files', 'start_num', 'end_num'
+    - 'files', 'start_num', 'end_num', 'step'
+    - 'keys'
+    - 'keys', 'step'
+    - 'keys', 'start_num', 'end_num'
+    - 'keys', 'start_num', 'end_num', 'step'
+    - 'start_num', 'end_num'
+    - 'start_num', 'end_num', 'step'
+
+    'keys' and 'files' cannot both be provided simultaneously.
 
     The hierarchy works as follow:
     1. If files (or keys) is given and start_num, end_num, step are not given
@@ -307,7 +323,8 @@ def get_file_indices(
     - start_num is present in the file list if step > 0
     - end_num is present in the list if step < 0
 
-    e.g.
+    Examples
+    --------
     A.  files = [1,3,4,6,7,9,10]
         gives: [1,3,4,6,7,9,10]
 
@@ -350,116 +367,157 @@ def get_file_indices(
 
     Parameters
     ----------
-    param_dict : TYPE, optional
-        DESCRIPTION. The default is None.
-    start_num : int, optional
+    param_dict : dict[str, int | None] | None
+        The dictionary containing parameters on the start and end numbers of the files
+        or HDF5 keys to be analysed, along with the step interval to use.
+        The default value is None.
+    start_num : int | None
         Starting value for the file index/number. The default is None.
-    end_num : int, optional
+    end_num : int | None
         End value for the file index/number. The default is None.
-    step : int, optional
+    step : int
         step value for the indices. The default is 1.
-    files : list, optional
+    files : list[int] | None
         List of file indices. The default is None.
-    keys : list, optional
+    keys : list[int] | None
         List of key indices for hdf5 file. The default is None.
 
     Returns
     -------
-    file_indices : list
-        List of file or key numbers.
-    numFKlist : list
-        Number of entries in file_indices.
-
+    indices_list : list
+        List of numbers in the file names or the HDF5 keys to process.
+    num_indices : int
+        Number of entries in indices_list.
     """
-    # Check once for existence of variables, then reuse
-    has_files = files is not None
-    has_keys = keys is not None
 
-    file_indices: list[int] = []
-    if param_dict is not None:
-        if isinstance(param_dict, dict):
-            # if is a dictionary assume from hdf5 files.
-            # dictionary from hdf5 functions
-            if "from" in param_dict:
-                start_num = param_dict["from"]
-            if "to" in param_dict:
-                end_num = param_dict["to"]
-            if "step" in param_dict:
-                step = param_dict["step"]
-        else:
-            if "start_num" in param_dict:
-                start_num = param_dict["datafile_StartNum"]
-            if "end_num" in param_dict:
-                end_num = param_dict["datafile_EndNum"]
-            if "step" in param_dict:
-                step = param_dict["datafile_Step"]
-    elif has_files and not has_keys:
-        file_indices = files
-    elif has_keys and not has_files:
-        file_indices = keys
-    elif not has_files and not has_keys and start_num is not None:
-        pass
-    elif start_num is not None:
-        if end_num == None:
-            raise ValueError("end_num is not defined")
-    else:
-        raise ValueError("Neither files, keys or start_num are defined")
+    indices_list: list[int] = []
+    match (
+        param_dict is not None,
+        files is not None,
+        keys is not None,
+    ):
+        case (True, True, True) | (True, True, False) | (True, False, True):
+            # 'param_dict' and 'files'/'keys' cannot be provided together
+            raise ValueError(
+                "'param_dict' cannot be provided together with 'files' and/or 'keys'."
+            )
+        case (False, True, True):
+            # Raise error if 'files' and 'keys' are both present,
+            raise ValueError("'files' and 'keys' cannot both be provided.")
+        case (False, True, False):
+            if files is None:
+                raise ValueError("'files'' was not provided")
+            indices_list = files
+        case (False, False, True):
+            if keys is None:
+                raise ValueError("'keys' was not provided")
+            indices_list = keys
+        case (True, False, False):
+            if param_dict is None:
+                raise ValueError("'param_dict' was not provided")
+            # Get 'start', 'stop', and 'step' from 'param_dict'
+            if isinstance(param_dict, dict):
+                # if is a dictionary assume from hdf5 files.
+                # dictionary from hdf5 functions
+                start_num = param_dict.get("from", None)
+                end_num = param_dict.get("to", None)
+                step = param_dict.get("step", 1)
+            else:
+                start_num = param_dict.get("datafile_StartNum", None)
+                end_num = param_dict.get("datafile_EndNum", None)
+                step = param_dict.get("datafile_Step", 1)
+            # Error if 'start_num' and 'end_num' could not be determined
+            if not (start_num is not None and end_num is not None):
+                raise ValueError("Could not construct indices list from 'param_dict'.")
+            start_num, end_num, step = map(int, (start_num, end_num, step))
 
-    # exclude negative numbers from start num and end_num.
-    # this just makes life simpler.
-    if start_num is not None and start_num < 0:
-        raise ValueError("start_num must be greater than 0")
-    if end_num is not None and end_num < 0:
-        raise ValueError("end_num must be greater than 0")
+    # Process differently depending on the absence/presence of 'start_num',
+    # 'end_num', 'indices_list'
+    match (start_num is not None, end_num is not None, len(indices_list) > 0):
+        case (True, False, False) | (False, True, False) | (False, False, False):
+            # Raise error if 'start_num' and/or 'end_num' are missing when 'indices_list'
+            # has been provided
+            raise ValueError(
+                "Both 'start_num' and 'end_num' must be set if neither 'files' or "
+                "'keys' were provided."
+            )
+        case (False, _, True):
+            # Reverse the list if step is negative
+            if step < 0:
+                indices_list = list(reversed(indices_list))
+            step = abs(step)
+            # Use 'step' to return every nth item in the list
+            indices_subset = [
+                index for i, index in enumerate(indices_list) if i % step == 0
+            ]
+            return indices_subset, len(indices_subset)
+        case (True, _, True) | (True, True, False):
+            # Assure type checker that 'start_num' is an int by this point
+            if start_num is None:
+                raise ValueError("'start_num' was not set")
 
-    if not file_indices:
-        # make Lst from start, stop and step.
-        if start_num > end_num:
-            start_num, end_num = end_num, start_num
-            end_num -= 1
-        else:
-            end_num += 1
+            # Do not allow negative values for 'start_num' and 'end_num'
+            if start_num < 0 or (end_num is not None and end_num < 0):
+                raise ValueError("'start_num' and 'end_num' cannot be negative values")
 
-        file_indices = np.arange(start_num, end_num, np.abs(step))
-        if step < 0:
-            # reverse list
-            file_indices = file_indices[::-1]
+            # If 'step' is negative, reverse the indices list after creation
+            reverse_list = step < 0
 
-    # make maximal list
-    # based on values in the list
-    if start_num is None:
-        s = np.min(file_indices)
-    elif start_num == -1:
-        s = np.max(file_indices)
-    else:
-        s = start_num
-    if end_num is None:
-        e = np.max(file_indices) + 1
-    elif start_num == -1:
-        s = np.min(file_indices)
-    else:
-        e = end_num + 1
+            if indices_list:
+                # Create a default 'end_num' if none was provided
+                end_num = end_num if end_num is not None else indices_list[-1]
 
-    if s > e:
-        s, e = e, s
-    #     e -= 1
-    else:
-        e += 1
-    list_all = np.arange(s, e + 1, np.abs(step))
-    if step < 0:
-        # reverse list
-        list_all = list_all[::-1]
-    # cut Lst to allowed values
-    if has_files and isinstance(files[0], str):
-        # files is a list of strings
-        file_indices = file_indices[list_all]
-    else:
-        # get list of matching values
-        file_indices = [x for x in list_all if x in file_indices]
-        # collapse incase it is a list of np arrays
-        file_indices = np.array(file_indices)
+                # Find the indices nearest to the specified 'start_num' and 'end_num'
+                idx_start: int | None = None
+                idx_end: int | None = None
+                if start_num > end_num:
+                    indices_list = list(reversed(indices_list))
+                    for i, num in enumerate(indices_list):
+                        if num <= start_num and idx_start is None:
+                            idx_start = i
+                        if num == end_num and idx_end is None:
+                            idx_end = i
+                        elif num < end_num and idx_end is None:
+                            idx_end = i - 1
+                else:
+                    for i, num in enumerate(indices_list):
+                        if num >= start_num and idx_start is None:
+                            idx_start = i
+                        if num == end_num and idx_end is None:
+                            idx_end = i
+                        elif num > end_num and idx_end is None:
+                            idx_end = i - 1
+                if not (idx_start is not None and idx_end is not None):
+                    raise ValueError(
+                        "Could not determine start and end indices using the start "
+                        "and end numbers provided"
+                    )
+                positions = range(idx_start, idx_end + 1, abs(step))
+                indices_list = [indices_list[i] for i in positions]
+                if reverse_list:
+                    indices_list = list(reversed(indices_list))
+                return indices_list, len(indices_list)
+            else:
+                # 'end_num' will be set at this point
+                if end_num is None:
+                    raise ValueError("'end_num' was not set")
 
-    return file_indices, len(file_indices)
+                # Generate number list that includes 'end_num' itself
+                if start_num < end_num:
+                    end_num += 1
+                    step = abs(step)
+                else:
+                    end_num -= 1
+                    step = -abs(step)
+                indices_list = list(range(start_num, end_num, step))
+                if reverse_list:
+                    indices_list = list(reversed(indices_list))
+                return indices_list, len(indices_list)
+    # This should never trigger, but is here to ensure a list is always returned
+    logger.warning(
+        "Unexpected combination of parameters detected, returning empty list"
+    )
+    return [], 0
 
 
 @overload

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -870,10 +870,11 @@ def peak_hkl(
     # Construct list of peaks to parse
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    elif isinstance(peak, int):
-        peaks = [peak]
-    elif isinstance(peak, list) and all(np.issubdtype(x, np.integer) for x in peak):
-        peaks = peak
+    # Accept Python and NumPy ints and convert to Python int
+    elif isinstance(peak, (int, np.integer)):
+        peaks = [int(peak)]
+    elif isinstance(peak, list) and all(isinstance(p, (int, np.integer)) for p in peak):
+        peaks = [int(p) for p in peak]
     else:
         raise TypeError(
             f"'peak' received an unsupported value: {peak} "
@@ -968,10 +969,11 @@ def peak_phase(
     # Convert input into a list of integers
     if peak == "all":
         peaks = list(range(len(orders["peak"])))
-    elif isinstance(peak, int):
-        peaks = [peak]
-    elif isinstance(peak, list) and all(np.issubdtype(x, np.integer) for x in peak):
-        peaks = peak
+    # Accept NumPy and Python ints and convert to Python ints
+    elif isinstance(peak, (int, np.integer)):
+        peaks = [int(peak)]
+    elif isinstance(peak, list) and all(isinstance(p, (int, np.integer)) for p in peak):
+        peaks = [int(p) for p in peak]
     else:
         raise TypeError(
             f"'peak' received an unsupported value: {peak} "

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -12,6 +12,7 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -463,61 +464,57 @@ def get_file_keys(
     return file_key_list, len(file_key_list)
 
 
-def any_terms_null(obj_to_inspect, val_to_find=None, index_path="", any_null=False):
+def has_value(
+    obj: dict | list | pd.DataFrame | str | int | float,
+    val: str | int | float | None = None,
+    path: str = "",
+    is_present: bool = False,
+):
     """
-    This function accepts a nested dictionary and list as argument
-    and iterates over all values of nested dictionaries and lists.
-    If any of the values are "Null" (or 'val_to_find') it returns True
+    This function recursively searches through lists, dictionaries, and
+    Pandas DataFrames for the specified value ("None" by default) and
+    returns True if any are detected.
 
     Parameters
     ----------
-    obj_to_inspect : dict, list
+    obj : dict, list, pd.DataFrame, str, int, float
         Nested dictionary or list of parameters to inspect.
-    val_to_find : str, float
+    val : str, int, float, optional
         Value or string to find in the dictionary. The default is None.
-    index_path : str
-        Index to look at in dictionary. The default is "".
-    any_null : bool, optional
-        Boolian for if 'val_to_find' are in dictionary. Used for iterating through nested structures.
+    path : str
+        Path taken through the dictionary/list. The default is "".
+    is_present : bool
+        Boolian for if 'val' are in dictionary. Used for iterating through nested structures.
         The default is False.
-
 
     Returns
     -------
-    any_null : bool
-        True - if any instances of 'val_to_find' have been found in the dicionary
-        False - if 'val_to_find' is not in dictionary.
+    is_present : bool
+        True - if any instances of 'val' have been found in the dicionary
+        False - if 'val' is not in dictionary.
 
     """
     # copied from https://python-forum.io/thread-24856.html
     # on 26th June 2021
-    if isinstance(obj_to_inspect, dict):
-        for key, value in obj_to_inspect.items():
-            any_null = any_terms_null(
-                value, val_to_find, index_path + f"['{key}']", any_null=any_null
-            )
-
-    elif isinstance(obj_to_inspect, list):
-        for key, value in enumerate(obj_to_inspect):
-            any_null = any_terms_null(
-                value, val_to_find, index_path + f"[{key}]", any_null=any_null
-            )
-
-    elif isinstance(obj_to_inspect, pd.DataFrame):
-        # look indata frame for values
-        tf = (obj_to_inspect.values == val_to_find).any()
-        any_null = tf or any_null
-
-    elif obj_to_inspect == val_to_find:
-        any_null = True
-        logger.moreinfo(
-            " ".join(map(str, [(f"Value {val_to_find} found at {index_path}")]))
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if is_present := has_value(value, val, path + f"['{key}']", is_present):
+                break  # Stop once one is found
+    elif isinstance(obj, list):
+        for key, value in enumerate(obj):
+            if is_present := has_value(value, val, path + f"[{key}]", is_present):
+                break  # Stop once one is found
+    elif isinstance(obj, pd.DataFrame):
+        # Look in DataFrame for values
+        is_present = (
+            bool((obj.isna() if pd.isna(val) else obj.eq(val)).any().any())
+            or is_present
         )
+    elif obj == val:
+        is_present = True
+        logger.moreinfo(" ".join(map(str, [(f"Value {val} found at {path}")])))
         # could be verbose if verbose logger.
-    else:
-        pass  # all seems in order
-
-    return any_null
+    return is_present
 
 
 def replace_null_terms(obj_to_inspect, val_to_find=None, index_path="", replace_with=0):

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -612,7 +612,7 @@ def replace_value(
     return obj
 
 
-def any_errors_huge(obj_to_inspect, large_errors=3, any_huge=False):
+def has_huge_errors(obj_to_inspect, large_errors=3, any_huge=False):
     """
     This function accepts a nested dictionary and list as argument
     and iterates over all values of nested dictionaries and lists.

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -12,7 +12,7 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,8 @@ import pandas as pd
 from cpf.util.logging import get_logger
 
 logger = get_logger("cpf.IO_functions")
+
+T = TypeVar("T")
 
 
 # Needed for JSON to save fitted parameters.
@@ -517,67 +519,75 @@ def has_value(
     return is_present
 
 
-def replace_value(obj_to_inspect, val_to_find=None, index_path="", replace_with=0):
+@overload
+def replace_value(
+    obj: dict,
+    old: Any = None,
+    new: Any = 0,
+    path: str = "",
+) -> dict: ...
+
+
+@overload
+def replace_value(
+    obj: list,
+    old: Any = None,
+    new: Any = 0,
+    path: str = "",
+) -> list: ...
+
+
+@overload
+def replace_value(
+    obj: pd.DataFrame,
+    old: Any = None,
+    new: Any = 0,
+    path: str = "",
+) -> pd.DataFrame: ...
+
+
+def replace_value(
+    obj: T,
+    old: Any = None,
+    new: Any = 0,
+    path: str = "",
+) -> T:
     """
-    This function accepts a nested dictionary and list as argument
-    and iterates over all values of nested dictionaries and lists.
-    If any of the values are "Null" (or 'val_to_find') it replaces it with
-    the value in 'replace_with'
+    Recursively replaces the specified old value in a dictionary, list, or Pandas
+    DataFrame with the desired new value, and returns the updated object.
 
     Parameters
     ----------
-    obj_to_inspect : dict, list
-        Nested dictionary or list of parameters to inspect.
-    val_to_find : str, float
+    obj : dict, list, pd.DataFrame
+        Nested dictionary/list or Pandas DataFrame to inspect.
+    old : str, int, float, None
         Value or string to find in the dictionary. The default is None.
-    index_path : str
-        Index to look at in dictionary. The default is "".
-    replace_with : str, float
+    new : str, int, float, None
         Value or string to use as replacement in the dictionary.
         The default is 0.
+    path : str
+        Path taken through the dictionary/list. The default is "".
 
     Returns
     -------
-    obj_to_inspect :  dict, list
+    obj :  dict, list, pd.DataFrame
         Nested dictionary or list of parameters.
 
     """
     # copied from https://python-forum.io/thread-24856.html
     # on 26th June 2021
 
-    if isinstance(obj_to_inspect, dict):
-        for key, value in obj_to_inspect.items():
-            obj_to_inspect[key] = replace_value(
-                deepcopy(value),
-                val_to_find,
-                index_path + f"['{key}']",
-                replace_with=replace_with,
-            )
-
-    elif isinstance(obj_to_inspect, list):
-        for key, value in enumerate(obj_to_inspect):
-            obj_to_inspect[key] = replace_value(
-                deepcopy(value),
-                val_to_find,
-                index_path + f"[{key}]",
-                replace_with=replace_with,
-            )
-
-    elif isinstance(obj_to_inspect, pd.DataFrame):
+    if isinstance(obj, (dict, list)):
+        for key, value in obj.items() if isinstance(obj, dict) else enumerate(obj):
+            obj[key] = replace_value(deepcopy(value), old, new, path + f"['{key}']")
+    elif isinstance(obj, pd.DataFrame):
         # replace contents of panda data frame
-        if val_to_find is not None:
-            obj_to_inspect = obj_to_inspect.replace(val_to_find, replace_with)
-
-    elif obj_to_inspect == val_to_find:  # and val_to_find is not None:
-        obj_to_inspect = replace_with
-        logger.moreinfo(
-            " ".join(map(str, [(f"Value {val_to_find} found at {index_path}")]))
-        )
-
-    else:
-        pass  # everything is in order
-
-    return obj_to_inspect
+        old = np.nan if old is None else old
+        obj = obj.replace(old, new)
+    elif obj == old:  # and old is not None:
+        obj = new
+        logger.moreinfo(" ".join(map(str, [(f"Value {old} found at {path}")])))
+    return obj
 
 
 def any_errors_huge(obj_to_inspect, large_errors=3, any_huge=False):

--- a/src/cpf/util/io.py
+++ b/src/cpf/util/io.py
@@ -25,7 +25,7 @@ logger = get_logger("cpf.IO_functions")
 # Needed for JSON to save fitted parameters.
 # Copied from https://stackoverflow.com/questions/3488934/simplejson-and-numpy-array#24375113
 # on 13th November 2018
-def json_numpy_serializer(o):
+def numpy_to_json(o):
     """
     Serialize numpy types for json
     Parameters:
@@ -33,7 +33,7 @@ def json_numpy_serializer(o):
     Example:
         >>> import json
         >>> a = np.array([1, 2, 3])
-        >>> json.dumps(a, default=json_numpy_serializer)
+        >>> json.dumps(a, default=numpy_to_json)
     """
     numpy_types = (
         np.bool_,

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -500,7 +500,7 @@ def test_replace_value(test_params: tuple[T, Any, Any, T]):
         assert replace_value(obj, old, new) == out
 
 
-def test_any_errors_huge():
+def test_has_huge_errors():
     pass
 
 

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -335,7 +335,7 @@ def test_has_value(
     assert has_value(obj, val) == result
 
 
-def test_replace_null_terms():
+def test_replace_value():
     pass
 
 

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -117,7 +117,7 @@ def test_image_list():
     pass
 
 
-def test_start_stop_files_to_list():
+def test_get_file_keys():
     pass
 
 

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -3,7 +3,14 @@ from typing import Any, TypeVar
 import numpy as np
 import pandas as pd
 import pytest
-from cpf.util.io import has_value, numpy_to_json, peak_hkl, peak_string, replace_value
+from cpf.util.io import (
+    has_value,
+    numpy_to_json,
+    peak_hkl,
+    peak_phase,
+    peak_string,
+    replace_value,
+)
 
 T = TypeVar("T", dict, list, pd.DataFrame)
 
@@ -870,8 +877,72 @@ def test_peak_hkl(
     assert output == peak_hkl(orders, peak=peak, string=as_string)
 
 
-def test_peak_phase():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Orders | Peak to analyse | Expected output
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            "all",
+            ["Fe-BCC", "CaO-FCC", "Cr-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            0,
+            ["Fe-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [0, 1],
+            ["Fe-BCC", "CaO-FCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            "0,1,2",
+            ["Fe-BCC", "CaO-FCC", "Cr-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"hkl": "110"},
+                    {"hkl": "220"},
+                    {"hkl": "330"},
+                ],
+            },
+            "all",
+            ["Unknown", "Unknown", "Unknown"],
+        ),
+    ),
+)
+def test_peak_phase(
+    test_params: tuple[dict[str, Any], str | int | list[int], list[str]],
+):
+    # Unpack test params
+    orders, peak, output = test_params
+    assert peak_phase(orders, peak) == output
 
 
 def test_title_file_names():

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -3,7 +3,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-from cpf.util.io import has_value, json_numpy_serializer
+from cpf.util.io import has_value, numpy_to_json
 
 
 @pytest.mark.parametrize(
@@ -102,12 +102,12 @@ from cpf.util.io import has_value, json_numpy_serializer
         ),
     ),
 )
-def test_json_numpy_serializer(
+def test_numpy_to_json(
     test_params,
 ):
     # Unpack test params
     input, expected_value, expected_type = test_params
-    output = json_numpy_serializer(input)
+    output = numpy_to_json(input)
     assert output == expected_value
     assert isinstance(output, expected_type)
 

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 import numpy as np
+import pandas as pd
 import pytest
-from cpf.util.io import json_numpy_serializer
+from cpf.util.io import has_value, json_numpy_serializer
 
 
 @pytest.mark.parametrize(
@@ -121,8 +124,215 @@ def test_get_file_keys():
     pass
 
 
-def test_any_terms_null():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Object | Value | Expected result
+        # =============================================================================
+        # True cases (value is present)
+        # =============================================================================
+        # Flat dict
+        (
+            {
+                key: value
+                for key, value in (
+                    (0, None),
+                    (1, 1),
+                    (2, 2),
+                )
+            },
+            None,
+            True,
+        ),
+        # Nested dict
+        (
+            {
+                key: {
+                    key: value
+                    for key, value in (
+                        (0, None),
+                        (1, 1),
+                        (2, 2),
+                    )
+                }
+                for key in (0, 1, 2)
+            },
+            None,
+            True,
+        ),
+        # Very nested dict
+        (
+            {0: {0: {0: {0: None}}}},
+            None,
+            True,
+        ),
+        # Flat list
+        (
+            [i for i in range(5)] + [None],
+            None,
+            True,
+        ),
+        # Nested list
+        (
+            [([i for i in range(5)] + [None]) * 5],
+            None,
+            True,
+        ),
+        # Very nested list
+        (
+            [
+                0,
+                [
+                    0,
+                    [
+                        0,
+                        [
+                            0,
+                            [
+                                0,
+                                None,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            None,
+            True,
+        ),
+        # Pandas dataframe (None)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [1.2, np.nan, 3.4, 4.5, None],
+                    "beta": [5.1, 6.2, None, np.nan, 9.5],
+                    "gamma": [np.nan, 2.3, 3.3, None, 5.5],
+                    "delta": [7.7, 8.8, np.nan, 1.1, None],
+                    "epsilon": [None, 0.5, 1.5, np.nan, 4.4],
+                }
+            ),
+            None,
+            True,
+        ),
+        # Pandas dataframe (Nan)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [1.2, np.nan, 3.4, 4.5, None],
+                    "beta": [5.1, 6.2, None, np.nan, 9.5],
+                    "gamma": [np.nan, 2.3, 3.3, None, 5.5],
+                    "delta": [7.7, 8.8, np.nan, 1.1, None],
+                    "epsilon": [None, 0.5, 1.5, np.nan, 4.4],
+                }
+            ),
+            np.nan,
+            True,
+        ),
+        # =============================================================================
+        # False cases (value is not present)
+        # =============================================================================
+        # Flat dict
+        (
+            {
+                key: value
+                for key, value in (
+                    (0, 0),
+                    (1, 1),
+                    (2, 2),
+                )
+            },
+            None,
+            False,
+        ),
+        # Nested dict
+        (
+            {
+                key: {
+                    key: value
+                    for key, value in (
+                        (0, 0),
+                        (1, 1),
+                        (2, 2),
+                    )
+                }
+                for key in (0, 1, 2)
+            },
+            None,
+            False,
+        ),
+        # Very nested dict
+        (
+            {0: {0: {0: {0: 0}}}},
+            None,
+            False,
+        ),
+        # Flat list
+        (
+            [i for i in range(5)],
+            None,
+            False,
+        ),
+        # Nested list
+        (
+            [[i for i in range(5)] * 5],
+            None,
+            False,
+        ),
+        # Very nested list
+        (
+            [
+                0,
+                [
+                    0,
+                    [
+                        0,
+                        [
+                            0,
+                            [
+                                0,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            None,
+            False,
+        ),
+        # Pandas dataframe (None)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)],
+                    "beta": [i for i in range(5)],
+                    "gamma": [i for i in range(5)],
+                    "delta": [i for i in range(5)],
+                    "epsilon": [i for i in range(5)],
+                }
+            ),
+            None,
+            False,
+        ),
+        # Pandas dataframe (Nan)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)],
+                    "beta": [i for i in range(5)],
+                    "gamma": [i for i in range(5)],
+                    "delta": [i for i in range(5)],
+                    "epsilon": [i for i in range(5)],
+                }
+            ),
+            np.nan,
+            False,
+        ),
+    ),
+)
+def test_has_value(
+    test_params: tuple[Any, Any, bool],
+):
+    # Unpack test params
+    obj, val, result = test_params
+    # Check that the result is as expected
+    assert has_value(obj, val) == result
 
 
 def test_replace_null_terms():

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from cpf.util.io import (
+    get_file_indices,
     has_value,
     numpy_to_json,
     peak_hkl,
@@ -129,8 +130,84 @@ def test_image_list():
     pass
 
 
-def test_get_file_indices():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Use param dict | Start | End | Step | Files | Keys | Expected list
+        # When passing in a param dict
+        (True, 1, 10, 1, None, None, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        (True, 1, 10, 4, None, None, [1, 5, 9]),
+        (True, 1, 10, -4, None, None, [9, 5, 1]),
+        (True, 10, 1, 4, None, None, [10, 6, 2]),
+        (True, 10, 1, -4, None, None, [2, 6, 10]),
+        # Passing in numbers directly
+        (False, 1, 10, 1, None, None, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        (False, 1, 10, 4, None, None, [1, 5, 9]),
+        (False, 1, 10, -4, None, None, [9, 5, 1]),
+        (False, 10, 1, 4, None, None, [10, 6, 2]),
+        (False, 10, 1, -4, None, None, [2, 6, 10]),
+        # Passing in files / keys
+        # With 'steps' only
+        (False, None, None, 1, [1, 2, 3, 4, 5, 6], None, [1, 2, 3, 4, 5, 6]),
+        (False, None, None, 2, None, [1, 2, 3, 4, 5, 6], [1, 3, 5]),
+        (False, None, None, -1, None, [1, 2, 3, 4, 5, 6], [6, 5, 4, 3, 2, 1]),
+        (False, None, None, -2, [1, 2, 3, 4, 5, 6], None, [6, 4, 2]),
+        # With 'start_num' and 'end_num'
+        # 'start_num' < 'end_num', 'step' > 0
+        (False, 1, 11, 1, None, [1, 3, 5, 7, 9, 11], [1, 3, 5, 7, 9, 11]),
+        (False, 1, 11, 2, [1, 3, 5, 7, 9, 11], None, [1, 5, 9]),
+        (False, 5, 11, 1, [1, 3, 5, 7, 9, 11], None, [5, 7, 9, 11]),
+        (False, 5, 9, 2, None, [1, 3, 5, 7, 9, 11], [5, 9]),
+        # 'start_num' > 'end_num', 'step' > 0
+        (False, 11, 1, 1, None, [1, 3, 5, 7, 9, 11], [11, 9, 7, 5, 3, 1]),
+        (False, 11, 1, 2, None, [1, 3, 5, 7, 9, 11], [11, 7, 3]),
+        (False, 9, 3, 1, [1, 3, 5, 7, 9, 11], None, [9, 7, 5, 3]),
+        (False, 9, 3, 2, [1, 3, 5, 7, 9, 11], None, [9, 5]),
+        # 'start_num' < 'end_num', 'step' < 0
+        (False, 1, 11, -1, [1, 3, 5, 7, 9, 11], None, [11, 9, 7, 5, 3, 1]),
+        (False, 1, 11, -2, [1, 3, 5, 7, 9, 11], None, [9, 5, 1]),
+        (False, 3, 9, -1, None, [1, 3, 5, 7, 9, 11], [9, 7, 5, 3]),
+        (False, 3, 9, -2, None, [1, 3, 5, 7, 9, 11], [7, 3]),
+        # 'start_num' > 'end_num', 'step' < 0
+        (False, 11, 1, -1, None, [1, 3, 5, 7, 9, 11], [1, 3, 5, 7, 9, 11]),
+        (False, 11, 1, -2, [1, 3, 5, 7, 9, 11], None, [3, 7, 11]),
+        (False, 9, 3, -1, None, [1, 3, 5, 7, 9, 11], [3, 5, 7, 9]),
+        (False, 9, 3, -2, [1, 3, 5, 7, 9, 11], None, [5, 9]),
+        # Nearest 'start_num' and 'end_num'
+        (False, 2, 10, 1, [1, 3, 4, 6, 8, 9, 11], None, [3, 4, 6, 8, 9]),
+        (False, 2, 10, -1, None, [1, 3, 4, 6, 8, 9, 11], [9, 8, 6, 4, 3]),
+        (False, 2, 10, 2, [1, 3, 4, 6, 8, 9, 11], None, [3, 6, 9]),
+        (False, 2, 10, -2, None, [1, 3, 4, 6, 8, 9, 11], [9, 6, 3]),
+        (False, 10, 2, 1, None, [1, 3, 4, 6, 8, 9, 11], [9, 8, 6, 4, 3]),
+        (False, 10, 2, -1, [1, 3, 4, 6, 8, 9, 11], None, [3, 4, 6, 8, 9]),
+        (False, 10, 2, 2, None, [1, 3, 4, 6, 8, 9, 11], [9, 6, 3]),
+        (False, 10, 2, -2, [1, 3, 4, 6, 8, 9, 11], None, [3, 6, 9]),
+    ),
+)
+def test_get_file_indices(
+    test_params: tuple[
+        bool, int | None, int | None, int, list[int] | None, list[int] | None, list[int]
+    ],
+):
+    # Unpack test params
+    use_param, start, end, step, files, keys, expected = test_params
+
+    param_dict: dict[str, int | None] | None = None
+    if use_param:
+        param_dict = {
+            "from": start,
+            "to": end,
+            "step": step,
+        }
+    result, length = get_file_indices(
+        param_dict=param_dict,
+        start_num=None if use_param else start,
+        end_num=None if use_param else end,
+        step=step,
+        files=files,
+        keys=keys,
+    )
+    assert result == expected
+    assert length == len(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -866,6 +866,115 @@ def test_peak_string(
             False,
             [[-1, -1, 0]],
         ),
+        # Check that NumPy integers are also accepted
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            [np.uint8(1), np.uint16(2)],
+            False,
+            [[2, 2, 0], [3, 3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            [np.uint32(1), np.uint64(2)],
+            False,
+            [[2, 2, 0], [3, 3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            np.int8(0),
+            False,
+            [[-1, -1, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            np.int16(0),
+            False,
+            [[-1, -1, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            np.int32(0),
+            False,
+            [[-1, -1, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            np.int64(0),
+            False,
+            [[-1, -1, 0]],
+        ),
         # If no 'hkl' key is provided
         (
             {
@@ -950,6 +1059,72 @@ def test_peak_hkl(
             },
             [0, 1],
             ["Fe-BCC", "CaO-FCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.uint8(0), np.uint16(1)],
+            ["Fe-BCC", "CaO-FCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.uint32(0), np.uint64(1)],
+            ["Fe-BCC", "CaO-FCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.int8(2)],
+            ["Cr-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.int16(2)],
+            ["Cr-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.int32(2)],
+            ["Cr-BCC"],
+        ),
+        (
+            {
+                "peak": [
+                    {"phase": "Fe-BCC"},
+                    {"phase": "CaO-FCC"},
+                    {"phase": "Cr-BCC"},
+                ],
+            },
+            [np.int64(2)],
+            ["Cr-BCC"],
         ),
         (
             {

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -122,7 +122,7 @@ def test_image_list():
     pass
 
 
-def test_get_file_keys():
+def test_get_file_indices():
     pass
 
 

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -3,7 +3,7 @@ from typing import Any, TypeVar
 import numpy as np
 import pandas as pd
 import pytest
-from cpf.util.io import has_value, numpy_to_json, peak_string, replace_value
+from cpf.util.io import has_value, numpy_to_json, peak_hkl, peak_string, replace_value
 
 T = TypeVar("T", dict, list, pd.DataFrame)
 
@@ -656,8 +656,218 @@ def test_peak_string(
     assert peak_string(fit_order, peak=peak, fname=as_filename) == output
 
 
-def test_peak_hkl():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Fit order | Peak | As a string? | Expected output
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            "all",
+            True,
+            ["110", "220", "330"],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            "all",
+            False,
+            [[1, 1, 0], [2, 2, 0], [3, 3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            "all",
+            True,
+            ["-1-10", "220", "-3-30"],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": [1, 1, 0],
+                    },
+                    {
+                        "hkl": [2, 2, 0],
+                    },
+                    {
+                        "hkl": [3, 3, 0],
+                    },
+                ]
+            },
+            "all",
+            False,
+            [[1, 1, 0], [2, 2, 0], [3, 3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": [-1, -1, 0],
+                    },
+                    {
+                        "hkl": [2, 2, 0],
+                    },
+                    {
+                        "hkl": [-3, -3, 0],
+                    },
+                ]
+            },
+            "all",
+            True,
+            ["-1-10", "220", "-3-30"],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            "all",
+            False,
+            [[-1, -1, 0], [2, 2, 0], [-3, -3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            "0,1",
+            True,
+            ["110", "220"],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            [1, 2],
+            False,
+            [[2, 2, 0], [3, 3, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "-1-10",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "-3-30",
+                    },
+                ]
+            },
+            0,
+            False,
+            [[-1, -1, 0]],
+        ),
+        # If no 'hkl' key is provided
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                ]
+            },
+            [1, 2],
+            False,
+            [[0, 0, 0], [0, 0, 0]],
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                ]
+            },
+            [1, 2],
+            True,
+            ["000", "000"],
+        ),
+    ),
+)
+def test_peak_hkl(
+    test_params: tuple[
+        dict[str, Any], str | int | list[int], bool, list[str | list[int]]
+    ],
+):
+    # Unpack test params
+    orders, peak, as_string, output = test_params
+    assert output == peak_hkl(orders, peak=peak, string=as_string)
 
 
 def test_peak_phase():

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -594,27 +594,6 @@ def test_has_huge_errors():
             [0, 1],
             "Fe-BCC-110_Fe-BCC-220",
         ),
-        (
-            {
-                "peak": [
-                    {
-                        "phase": "Fe-BCC",
-                        "hkl": "110",
-                    },
-                    {
-                        "phase": "Fe-BCC",
-                        "hkl": "220",
-                    },
-                    {
-                        "phase": "Fe-BCC",
-                        "hkl": "330",
-                    },
-                ]
-            },
-            False,
-            "1,2,",
-            "Fe-BCC (220) & Fe-BCC (330)",
-        ),
         # If 'phase' key is absent
         (
             {
@@ -631,8 +610,8 @@ def test_has_huge_errors():
                 ]
             },
             False,
-            "1,2",
-            "Peak (220) & Peak (330)",
+            "all",
+            "Peak (110) & Peak (220) & Peak (330)",
         ),
         # If 'hkl' key is absent
         (
@@ -650,8 +629,8 @@ def test_has_huge_errors():
                 ]
             },
             False,
-            "1,2",
-            "Fe-BCC (2) & Fe-BCC (3)",
+            "all",
+            "Fe-BCC (1) & Fe-BCC (2) & Fe-BCC (3)",
         ),
     ),
 )
@@ -788,24 +767,6 @@ def test_peak_string(
                     },
                 ]
             },
-            "0,1",
-            True,
-            ["110", "220"],
-        ),
-        (
-            {
-                "peak": [
-                    {
-                        "hkl": "110",
-                    },
-                    {
-                        "hkl": "220",
-                    },
-                    {
-                        "hkl": "330",
-                    },
-                ]
-            },
             [1, 2],
             False,
             [[2, 2, 0], [3, 3, 0]],
@@ -874,7 +835,7 @@ def test_peak_hkl(
 ):
     # Unpack test params
     orders, peak, as_string, output = test_params
-    assert output == peak_hkl(orders, peak=peak, string=as_string)
+    assert output == peak_hkl(orders, peak=peak, as_string=as_string)
 
 
 @pytest.mark.parametrize(
@@ -912,17 +873,6 @@ def test_peak_hkl(
             },
             [0, 1],
             ["Fe-BCC", "CaO-FCC"],
-        ),
-        (
-            {
-                "peak": [
-                    {"phase": "Fe-BCC"},
-                    {"phase": "CaO-FCC"},
-                    {"phase": "Cr-BCC"},
-                ],
-            },
-            "0,1,2",
-            ["Fe-BCC", "CaO-FCC", "Cr-BCC"],
         ),
         (
             {

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -1,9 +1,11 @@
-from typing import Any
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 import pytest
-from cpf.util.io import has_value, numpy_to_json
+from cpf.util.io import has_value, numpy_to_json, replace_value
+
+T = TypeVar("T", dict, list, pd.DataFrame)
 
 
 @pytest.mark.parametrize(
@@ -335,8 +337,167 @@ def test_has_value(
     assert has_value(obj, val) == result
 
 
-def test_replace_value():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Initial object | Old value | New value | Expected output
+        # Simple dict
+        (
+            {
+                0: None,
+                1: 1,
+                2: None,
+                3: 3,
+            },
+            None,
+            0,
+            {
+                0: 0,
+                1: 1,
+                2: 0,
+                3: 3,
+            },
+        ),
+        # Nested dict
+        (
+            {
+                0: {
+                    0: None,
+                    1: 1,
+                    2: None,
+                    3: 3,
+                },
+                1: {
+                    0: None,
+                    1: 1,
+                    2: None,
+                    3: 3,
+                },
+            },
+            None,
+            0,
+            {
+                0: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                    3: 3,
+                },
+                1: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                    3: 3,
+                },
+            },
+        ),
+        # Simple list
+        (
+            [None, 1, 2, None, 4],
+            None,
+            0,
+            [0, 1, 2, 0, 4],
+        ),
+        # Nested list
+        (
+            [[None, 1, 2, None, 4] * 5],
+            None,
+            0,
+            [[0, 1, 2, 0, 4] * 5],
+        ),
+        # Pandas DataFrame (None)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [None],
+                    "beta": [i for i in range(5)] + [None],
+                }
+            ),
+            None,
+            0,
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [0],
+                    "beta": [i for i in range(5)] + [0],
+                }
+            ),
+        ),
+        # Pandas DataFrame (NaN)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [np.nan],
+                    "beta": [i for i in range(5)] + [np.nan],
+                }
+            ),
+            np.nan,
+            0,
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [0],
+                    "beta": [i for i in range(5)] + [0],
+                }
+            ),
+        ),
+        # Pandas DataFrame (check that NaN and None are interchangeable)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [None],
+                    "beta": [i for i in range(5)] + [None],
+                }
+            ),
+            np.nan,
+            0,
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [0],
+                    "beta": [i for i in range(5)] + [0],
+                }
+            ),
+        ),
+        # Pandas DataFrame (check that NaN and None are interchangeable)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [np.nan],
+                    "beta": [i for i in range(5)] + [np.nan],
+                }
+            ),
+            None,
+            np.nan,
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [None],
+                    "beta": [i for i in range(5)] + [None],
+                }
+            ),
+        ),
+        # Pandas DataFrame (check that replacing with None works)
+        (
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [np.nan],
+                    "beta": [i for i in range(5)] + [np.nan],
+                }
+            ),
+            None,
+            None,
+            pd.DataFrame(
+                {
+                    "alpha": [i for i in range(5)] + [None],
+                    "beta": [i for i in range(5)] + [None],
+                }
+            ),
+        ),
+    ),
+)
+def test_replace_value(test_params: tuple[T, Any, Any, T]):
+    # Unpack test params
+    obj, old, new, out = test_params
+    if isinstance(obj, pd.DataFrame) and isinstance(out, pd.DataFrame):
+        assert replace_value(obj, old, new).astype(float).equals(out.astype(float))
+    else:
+        assert replace_value(obj, old, new) == out
 
 
 def test_any_errors_huge():

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -3,7 +3,7 @@ from typing import Any, TypeVar
 import numpy as np
 import pandas as pd
 import pytest
-from cpf.util.io import has_value, numpy_to_json, replace_value
+from cpf.util.io import has_value, numpy_to_json, peak_string, replace_value
 
 T = TypeVar("T", dict, list, pd.DataFrame)
 
@@ -504,8 +504,156 @@ def test_has_huge_errors():
     pass
 
 
-def test_peak_string():
-    pass
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Fit order | Use file name? | Peak | Expected output
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Other",
+                        "hkl": "000",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": 110,
+                    },
+                ],
+            },
+            False,
+            "all",
+            "Other (000) & Fe-BCC (110)",
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "110",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "220",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "330",
+                    },
+                ]
+            },
+            True,
+            "all",
+            "Fe-BCC-110_Fe-BCC-220_Fe-BCC-330",
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "110",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "220",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "330",
+                    },
+                ]
+            },
+            False,
+            0,
+            "Fe-BCC (110)",
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "110",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "220",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "330",
+                    },
+                ]
+            },
+            True,
+            [0, 1],
+            "Fe-BCC-110_Fe-BCC-220",
+        ),
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "110",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "220",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                        "hkl": "330",
+                    },
+                ]
+            },
+            False,
+            "1,2,",
+            "Fe-BCC (220) & Fe-BCC (330)",
+        ),
+        # If 'phase' key is absent
+        (
+            {
+                "peak": [
+                    {
+                        "hkl": "110",
+                    },
+                    {
+                        "hkl": "220",
+                    },
+                    {
+                        "hkl": "330",
+                    },
+                ]
+            },
+            False,
+            "1,2",
+            "Peak (220) & Peak (330)",
+        ),
+        # If 'hkl' key is absent
+        (
+            {
+                "peak": [
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                    {
+                        "phase": "Fe-BCC",
+                    },
+                ]
+            },
+            False,
+            "1,2",
+            "Fe-BCC (2) & Fe-BCC (3)",
+        ),
+    ),
+)
+def test_peak_string(
+    test_params: tuple[dict[str, Any], bool, str | int | list[int], str],
+):
+    # Unpack the test params
+    fit_order, as_filename, peak, output = test_params
+    assert peak_string(fit_order, peak=peak, fname=as_filename) == output
 
 
 def test_peak_hkl():

--- a/tests/util/test_io.py
+++ b/tests/util/test_io.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from cpf.IO_functions import json_numpy_serializer
+from cpf.util.io import json_numpy_serializer
 
 
 @pytest.mark.parametrize(
@@ -107,3 +107,63 @@ def test_json_numpy_serializer(
     output = json_numpy_serializer(input)
     assert output == expected_value
     assert isinstance(output, expected_type)
+
+
+def test_file_list():
+    pass
+
+
+def test_image_list():
+    pass
+
+
+def test_start_stop_files_to_list():
+    pass
+
+
+def test_any_terms_null():
+    pass
+
+
+def test_replace_null_terms():
+    pass
+
+
+def test_any_errors_huge():
+    pass
+
+
+def test_peak_string():
+    pass
+
+
+def test_peak_hkl():
+    pass
+
+
+def test_peak_phase():
+    pass
+
+
+def test_title_file_names():
+    pass
+
+
+def test_make_outfile_name():
+    pass
+
+
+def test_lmfit_fix_int_data_type():
+    pass
+
+
+def test_number_to_string():
+    pass
+
+
+def test_licit_filename():
+    pass
+
+
+def test_figure_suptitle_space():
+    pass


### PR DESCRIPTION
This PR focuses on improving the test coverage, fixing type hinting issues, and streamlining the operational logic for the functions in `cpf.util.io` (formerly `cpf.IO_functions`).

Much of the diff is caused by the `pre-commit` checks fixing whitespace, rearranging imports, and rewriting overly long lines in the scanned files. Actual direct changes constitute about +900/-450 lines. 

Key files that need reviewing:
* `cpf.util.io`
* `tests.util.test_io`

**Summary of Changes**
* Renamed `cpf.IO_functions` to `cpf.util.io`
  * The functions in this module are all meant to be helper functions, and should be stored as such in a separate utility modules folder
* Renamed function `json_numpy_serializer` to `numpy_to_json`
* Renamed function `StartStopFilesToList` to `get_file_indices` and optimised index generation logic
* Renamed `any_terms_null` to `has_value` and optimised it
  * This function can work with non-`None` values, so `any_terms_null` is not a good indicator of its scope
* Renamed `replace_null_terms` to `replace_value` and optimised it
  * Done for similar reasons to the above
* Renamed `any_errors_huge` to `has_huge_errors`
* Updated `peak_string`, `peak_hkl` and `peak_phase` to take in the following values for `peak`:
  * An int
  * A list of ints
  * "all"

* Added tests for the following functions:
  * `has_value`
  * `replace_value`
  * `peak_string`
  * `peak_hkl`
  * `peak_phase`
  * `get_file_indices`